### PR TITLE
feat: validate dynamic app config query string

### DIFF
--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -27,7 +27,7 @@ window.config = {
   },
   // filterQueryParam: false,
   /* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
-  useDynamicConfig: {
+  dangerouslyUseDynamicConfig: {
     enabled: false,
     regex: /.*/,
   },

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -26,6 +26,11 @@ window.config = {
     prefetch: 25,
   },
   // filterQueryParam: false,
+  /* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
+  useDynamicConfig: {
+    enabled: false,
+    regex: /.*/,
+  },
   dataSources: [
     {
       friendlyName: 'dcmjs DICOMWeb Server',

--- a/platform/viewer/src/index.js
+++ b/platform/viewer/src/index.js
@@ -17,7 +17,7 @@ import ReactDOM from 'react-dom';
 import loadDynamicImports, { loadRuntimeImports } from './pluginImports.js';
 import loadDynamicConfig from './loadDynamicConfig';
 
-Promise.all([loadDynamicImports(), loadDynamicConfig()]).then(arr => {
+Promise.all([loadDynamicImports(), loadDynamicConfig(window.config)]).then(arr => {
   /**
    * Combine our appConfiguration with installed extensions and modes.
    * In the future appConfiguration may contain modes added at runtime.

--- a/platform/viewer/src/loadDynamicConfig.js
+++ b/platform/viewer/src/loadDynamicConfig.js
@@ -1,7 +1,7 @@
 export default async config => {
-  const useDynamicConfig = config.useDynamicConfig;
+  const useDynamicConfig = config.dangerouslyUseDynamicConfig;
 
-  // Check if useDynamicConfig enabled
+  // Check if dangerouslyUseDynamicConfig enabled
   if (useDynamicConfig.enabled) {
     // If enabled then get configUrl param
     let query = new URLSearchParams(window.location.search);

--- a/platform/viewer/src/loadDynamicConfig.js
+++ b/platform/viewer/src/loadDynamicConfig.js
@@ -1,17 +1,30 @@
-export default async () => {
-  let query = new URLSearchParams(window.location.search);
-  let configUrl = query.get('configUrl');
+export default async config => {
+  const useDynamicConfig = config.useDynamicConfig;
 
-  if (!configUrl) {
-    // Handle OIDC redirects
-    const obj = JSON.parse(sessionStorage.getItem('ohif-redirect-to'));
-    if (obj) {
-      const query = new URLSearchParams(obj.search);
-      configUrl = query.get('configUrl');
+  // Check if useDynamicConfig enabled
+  if (useDynamicConfig.enabled) {
+    // If enabled then get configUrl param
+    let query = new URLSearchParams(window.location.search);
+    let configUrl = query.get('configUrl');
+
+    if (!configUrl) {
+      // Handle OIDC redirects
+      const obj = JSON.parse(sessionStorage.getItem('ohif-redirect-to'));
+      if (obj) {
+        const query = new URLSearchParams(obj.search);
+        configUrl = query.get('configUrl');
+      }
+    } else {
+      // validate regex
+      const regex = useDynamicConfig.regex;
+
+      if (regex.test(configUrl)) {
+        const response = await fetch(configUrl);
+        return response.json();
+      } else {
+        return null;
+      }
     }
-  } else {
-    const response = await fetch(configUrl);
-    return response.json();
   }
 
   return null;


### PR DESCRIPTION
### PR Checklist

The PR allows to validate `configUrl` query string if passed against the regex provided in local configurations.

**Points to consider:**
- User have to enable this feature by setting `dangerouslyUseDynamicConfig.enabled:true`. By default it is `false`. 
- Regex helps to avoid easy exploit
- User must set `cross-origin = same-origin` to avoid potential harder exploit

**Sample local config:**
```
/* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
  dangerouslyUseDynamicConfig: {
    enabled: false,
    regex: /.*/,
  }
```

@Ouwen This PR is related to another PR [OHIF#2925](https://github.com/OHIF/Viewers/pull/2925)

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review


<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
