### PR TITLE
docs: update cross-origin description for dangerouslyUseDynamicConfig

### DIFF
--- a/platform/docs/docs/configuration/configurationFiles.md
+++ b/platform/docs/docs/configuration/configurationFiles.md
@@ -120,7 +120,7 @@ if auth headers are used, a preflight request is required.
 Points to consider while using `dangerouslyUseDynamicConfig`:<br/>
   - User have to enable this feature by setting `dangerouslyUseDynamicConfig.enabled:true`. By default it is `false`.
   - Regex helps to avoid easy exploit. Dafault is `/.*/`. Setup your own regex to choose a specific source of configuration only.
-  - User must set `cross-origin:same-origin` to avoid potential harder exploit.
+  - System administrators can return `cross-origin: same-origin` with OHIF files to disallow any loading from other origin. It will block read access to resources loaded from a different origin to avoid potential attack vector.
 
   - Example config:
     ```js


### PR DESCRIPTION
### PR Checklist
This PR updated the document description about  setting `dangerouslyUseDynamicConfig` usage to `cross-origin: same-origin`.

@Ouwen This PR is related to another PR https://github.com/OHIF/Viewers/pull/2925 and covering @wayfarer3130 comments about description.

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
