### PR TITLE
Gradienthealth/Segmentation with DicomJson

### DIFF
--- a/extensions/cornerstone/src/utils/dicomLoaderService.js
+++ b/extensions/cornerstone/src/utils/dicomLoaderService.js
@@ -176,6 +176,7 @@ class DicomLoaderService {
       authorizationHeaders,
       wadoRoot,
       wadoUri,
+      instance,
     } = dataset;
     // Retrieve wadors or just try to fetch wadouri
     if (!someInvalidStrings(wadoRoot)) {
@@ -188,6 +189,9 @@ class DicomLoaderService {
       );
     } else if (!someInvalidStrings(wadoUri)) {
       return fetchIt(wadoUri, { headers: authorizationHeaders });
+    } else if (!someInvalidStrings(instance?.url)) {
+      const uri = instance.url.replace(/^dicomweb:/, '');
+      return fetchIt(uri, { headers: authorizationHeaders });
     }
   }
 

--- a/platform/app/public/config/gradient.js
+++ b/platform/app/public/config/gradient.js
@@ -37,7 +37,7 @@ window.config = {
         'profile',
         'openid',
         'https://www.googleapis.com/auth/spreadsheets',
-        'https://www.googleapis.com/auth/devstorage.read_only',
+        'https://www.googleapis.com/auth/devstorage.read_write',
         'https://www.googleapis.com/auth/bigquery.readonly',
         'https://www.googleapis.com/auth/drive.metadata.readonly',
         'https://www.googleapis.com/auth/drive.readonly',


### PR DESCRIPTION
I changed the google storage authority from read_only to read_write.
I also added a option to load dicom images using url in the instance, which is currently used to load Segmentation uploaded through bq DicomJson datasource in GradientExtensionsAndModes. 