### PR TITLE
Merge Nightly to Production

### DIFF
--- a/extensions/cornerstone-dicom-seg/src/getSopClassHandlerModule.ts
+++ b/extensions/cornerstone-dicom-seg/src/getSopClassHandlerModule.ts
@@ -2,6 +2,7 @@ import { utils } from '@ohif/core';
 import { metaData, triggerEvent, eventTarget } from '@cornerstonejs/core';
 import { CONSTANTS, segmentation as cstSegmentation } from '@cornerstonejs/tools';
 import { adaptersSEG, Enums } from '@cornerstonejs/adapters';
+import { internal } from '@cornerstonejs/dicom-image-loader';
 
 import { SOPClassHandlerId } from './id';
 import { dicomlabToRGB } from './utils/dicomlabToRGB';
@@ -97,8 +98,10 @@ function _getDisplaySetsFromSeries(
     displaySet.referencedDisplaySetInstanceUID = referencedDisplaySet.displaySetInstanceUID;
   }
 
+  const codHeaders = internal.getCodHeaders();
+
   displaySet.load = async ({ headers }) =>
-    await _load(displaySet, servicesManager, extensionManager, headers);
+    await _load(displaySet, servicesManager, extensionManager, { ...headers, ...codHeaders });
 
   return [displaySet];
 }

--- a/extensions/cornerstone/src/components/OPFSManagementTool/OPFSManagementTool.tsx
+++ b/extensions/cornerstone/src/components/OPFSManagementTool/OPFSManagementTool.tsx
@@ -28,9 +28,12 @@ import { Study } from './types';
 import {
   clearPreviousOPFSVersionData,
   deleteFoldersFromOPFS,
+  formatSize,
   getOPFSData,
   hybridGlobalFilter,
+  purgeOldFilesFromOPFS,
 } from './utils';
+import { OPFS_PURGE_METADATA } from './constants';
 
 const columnHelper = createColumnHelper<Study>();
 
@@ -66,23 +69,21 @@ const columns: ColumnDef<Study>[] = [
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
         >
-          StudyInstanceUID
-          <ArrowUpDown className="h-4 w-4" />
+          StudyInstanceUID <ArrowUpDown className="h-4 w-4" />
         </Button>
       );
     },
     cell: ({ row }) => <div>{row.getValue('study-uid')}</div>,
   },
-  {
-    accessorKey: 'study-description',
+  columnHelper.accessor('study-description', {
+    accessorFn: row => row['study-description'] || '',
     header: ({ column }) => {
       return (
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
         >
-          StudyDescription
-          <ArrowUpDown className="h-4 w-4" />
+          StudyDescription <ArrowUpDown className="h-4 w-4" />
         </Button>
       );
     },
@@ -97,7 +98,7 @@ const columns: ColumnDef<Study>[] = [
         </Tooltip>
       );
     },
-  },
+  }),
   columnHelper.accessor('study-modalities', {
     accessorFn: row => row['study-modalities'].sort().join(', '),
     header: ({ column }) => {
@@ -106,8 +107,7 @@ const columns: ColumnDef<Study>[] = [
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
         >
-          Modalities
-          <ArrowUpDown className="h-4 w-4" />
+          Modalities <ArrowUpDown className="h-4 w-4" />
         </Button>
       );
     },
@@ -126,18 +126,7 @@ const columns: ColumnDef<Study>[] = [
   columnHelper.accessor('study-size', {
     accessorFn: row => {
       const size: number = row['study-size'];
-      const oneGB = 1024 * 1024 * 1024,
-        oneMB = 1024 * 1024,
-        oneKB = 1024;
-
-      if (size >= oneGB) {
-        return `${(size / oneGB).toFixed(2)} GB`;
-      } else if (size >= oneMB) {
-        return `${(size / oneMB).toFixed(2)} MB`;
-      } else if (size >= oneKB) {
-        return `${(size / oneKB).toFixed(2)} KB`;
-      }
-      return `${size} bytes`;
+      return formatSize(size);
     },
     sortingFn: (rowA, rowB, columnId) => {
       const sizeA = rowA.original[columnId];
@@ -157,27 +146,30 @@ const columns: ColumnDef<Study>[] = [
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
         >
-          Size
-          <ArrowUpDown className="h-4 w-4" />
+          Size <ArrowUpDown className="h-4 w-4" />
         </Button>
       );
     },
     cell: ({ row }) => <div>{row.getValue('study-size')}</div>,
   }),
   columnHelper.accessor('study-last-modified', {
-    accessorFn: row => new Date(row['study-last-modified']).toGMTString(),
+    accessorFn: row => new Date(row['study-last-modified']),
+    sortingFn: 'datetime',
     header: ({ column }) => {
       return (
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
         >
-          Last Modified
-          <ArrowUpDown className="h-4 w-4" />
+          Last Modified <ArrowUpDown className="h-4 w-4" />
         </Button>
       );
     },
-    cell: ({ row }) => <div>{row.getValue('study-last-modified')}</div>,
+    cell: ({ row }) => {
+      const value: Date = row.getValue('study-last-modified');
+      const formattedDate = value.toDateString() + ', ' + value.toLocaleTimeString();
+      return <div>{formattedDate}</div>;
+    },
   }),
   {
     id: 'actions',
@@ -247,6 +239,7 @@ export default function OPFSManagementTool() {
 
   const refreshOPFSData = async () => {
     const fetchedData = await getOPFSData();
+    table.toggleAllPageRowsSelected(false);
     setData(fetchedData);
   };
 
@@ -263,6 +256,19 @@ export default function OPFSManagementTool() {
       console.warn('Error deleting selected rows');
       refreshOPFSData();
     }
+  };
+
+  const purgeOldFiles = async (time: number) => {
+    await purgeOldFilesFromOPFS(time);
+    refreshOPFSData();
+  };
+
+  const calculateTotalSize = (list: Study[]) => {
+    const totalSize = list.reduce((total, study) => {
+      return total + study['study-size'];
+    }, 0);
+
+    return formatSize(totalSize);
   };
 
   return (
@@ -300,6 +306,28 @@ export default function OPFSManagementTool() {
         >
           Debug Copy
         </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              className="ml-2"
+            >
+              Purge <ChevronDown />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Files older than</DropdownMenuLabel>
+            {OPFS_PURGE_METADATA.map(option => (
+              <DropdownMenuItem
+                key={option.label}
+                className="capitalize"
+                onClick={() => purgeOldFiles(option.time)}
+              >
+                {option.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -378,6 +406,12 @@ export default function OPFSManagementTool() {
         <div className="text-muted-foreground flex-1 text-sm">
           {table.getFilteredSelectedRowModel().rows.length} of{' '}
           {table.getFilteredRowModel().rows.length} row(s) selected.
+          {table.getFilteredSelectedRowModel().rows.length
+            ? `  ${calculateTotalSize(data.filter((study, index) => rowSelection[index]))}.`
+            : ''}
+        </div>
+        <div className="text-muted-foreground flex-1 text-sm">
+          Total size: {calculateTotalSize(data)}
         </div>
         <div className="space-x-2">
           <Button

--- a/extensions/cornerstone/src/components/OPFSManagementTool/constants.ts
+++ b/extensions/cornerstone/src/components/OPFSManagementTool/constants.ts
@@ -1,2 +1,29 @@
 export const OPFS_VERSION_STORAGE_KEY = 'gh-opfs-path-version';
 export const CURRENT_OPFS_VERSION = 1;
+
+export const OPFS_PURGE_METADATA = [
+  {
+    label: 'All',
+    time: null,
+  },
+  {
+    label: '1 Hour',
+    time: 1000 * 60 * 60,
+  },
+  {
+    label: '4 Hours',
+    time: 1000 * 60 * 60 * 4,
+  },
+  {
+    label: '12 Hours',
+    time: 1000 * 60 * 60 * 12,
+  },
+  {
+    label: '1 Day',
+    time: 1000 * 60 * 60 * 24,
+  },
+  {
+    label: '1 Week',
+    time: 1000 * 60 * 60 * 24 * 7,
+  },
+];

--- a/extensions/cornerstone/src/components/OPFSManagementTool/utils.ts
+++ b/extensions/cornerstone/src/components/OPFSManagementTool/utils.ts
@@ -274,6 +274,61 @@ export async function deleteFoldersFromOPFS(folderPaths: string[]) {
   }
 }
 
+export async function purgeOldFilesFromOPFS(maxAgeMs?: number): Promise<void> {
+  if (!maxAgeMs) {
+    try {
+      const rootHandle = await getOPFSRootHandle();
+      // @ts-ignore
+      await rootHandle.remove({ recursive: true });
+    } catch (error) {
+      console.warn(`Error purging files: ${error.message}`);
+    }
+    return;
+  }
+
+  const cutoffTime = Date.now() - maxAgeMs;
+
+  async function traverseAndClean(dirHandle: FileSystemDirectoryHandle): Promise<void> {
+    const entries: (FileSystemFileHandle | FileSystemDirectoryHandle)[] = [];
+    // @ts-ignore
+    for await (const subDirHandle of dirHandle.values()) {
+      entries.push(subDirHandle);
+    }
+
+    await Promise.all(
+      entries.map(async subDirHandle => {
+        if (!maxAgeMs) {
+          await dirHandle.removeEntry(subDirHandle.name, { recursive: true });
+        }
+
+        if (subDirHandle.kind === 'file') {
+          const fileHandle = subDirHandle as FileSystemFileHandle;
+          const file = await fileHandle.getFile();
+
+          if (file.lastModified < cutoffTime) {
+            await dirHandle.removeEntry(file.name);
+          }
+        } else if (subDirHandle.kind === 'directory') {
+          await traverseAndClean(subDirHandle);
+
+          // @ts-ignore
+          if ((await subDirHandle.values().next()).done) {
+            // Subdirectory is empty: DELETE it from the parent
+            await dirHandle.removeEntry(subDirHandle.name);
+          }
+        }
+      })
+    );
+  }
+
+  try {
+    const rootHandle = await getOPFSRootHandle();
+    await traverseAndClean(rootHandle);
+  } catch (error) {
+    console.warn(`Error clearing partial files: ${error.message}`);
+  }
+}
+
 export function hybridGlobalFilter(
   row: Row<Study>,
   columnId: string,
@@ -296,4 +351,19 @@ export function hybridGlobalFilter(
 
   // This runs if the input wasn't a valid regex pattern OR if the try-catch failed.
   return cellValueString.includes(filterValueString.toLowerCase());
+}
+
+export function formatSize(size = 0): string {
+  const oneGB = 1024 * 1024 * 1024,
+    oneMB = 1024 * 1024,
+    oneKB = 1024;
+
+  if (size >= oneGB) {
+    return `${(size / oneGB).toFixed(2)} GB`;
+  } else if (size >= oneMB) {
+    return `${(size / oneMB).toFixed(2)} MB`;
+  } else if (size >= oneKB) {
+    return `${(size / oneKB).toFixed(2)} KB`;
+  }
+  return `${size} bytes`;
 }

--- a/extensions/cornerstone/src/components/OPFSManagementTool/utils.ts
+++ b/extensions/cornerstone/src/components/OPFSManagementTool/utils.ts
@@ -275,6 +275,8 @@ export async function deleteFoldersFromOPFS(folderPaths: string[]) {
 }
 
 export async function purgeOldFilesFromOPFS(maxAgeMs?: number): Promise<void> {
+  // If the maxAgeMs value is null, clear the OPFS.
+  // If the user selected to purge 'All' OPFS data, the maxAgeMs will be null.
   if (!maxAgeMs) {
     try {
       const rootHandle = await getOPFSRootHandle();

--- a/extensions/cornerstone/src/components/OPFSManagementTool/utils.ts
+++ b/extensions/cornerstone/src/components/OPFSManagementTool/utils.ts
@@ -120,9 +120,9 @@ function structureData(fileDetails: FileDetails[]): Study[] {
     }
 
     const firstInstance = Object.values(metadataFile.data.cod.instances)[0];
-    const studyDescription = firstInstance.metadata['00081030']?.Value[0];
-    const seriesDescription = firstInstance.metadata['0008103E']?.Value[0];
-    const seriesModality = firstInstance.metadata['00080060']?.Value[0];
+    const studyDescription = firstInstance.metadata['00081030']?.Value?.[0];
+    const seriesDescription = firstInstance.metadata['0008103E']?.Value?.[0];
+    const seriesModality = firstInstance.metadata['00080060']?.Value?.[0];
 
     let totalSeriesSize = 0;
     let seriesMostRecentModified = 0;

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -49,6 +49,6 @@
     "@cornerstonejs/calculate-suv": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.uniqby": "^4.7.0",
-    "cod-dicomweb-server": "^1.3.14"
+    "cod-dicomweb-server": "^1.3.15"
   }
 }

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -49,6 +49,6 @@
     "@cornerstonejs/calculate-suv": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.uniqby": "^4.7.0",
-    "cod-dicomweb-server": "^1.3.15"
+    "cod-dicomweb-server": "^1.3.16"
   }
 }

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -49,6 +49,6 @@
     "@cornerstonejs/calculate-suv": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.uniqby": "^4.7.0",
-    "cod-dicomweb-server": "^1.3.13"
+    "cod-dicomweb-server": "^1.3.14"
   }
 }

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -49,6 +49,6 @@
     "@cornerstonejs/calculate-suv": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.uniqby": "^4.7.0",
-    "cod-dicomweb-server": "^1.3.11"
+    "cod-dicomweb-server": "^1.3.12"
   }
 }

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -49,6 +49,6 @@
     "@cornerstonejs/calculate-suv": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.uniqby": "^4.7.0",
-    "cod-dicomweb-server": "^1.3.12"
+    "cod-dicomweb-server": "^1.3.13"
   }
 }

--- a/extensions/default/src/DicomWebDataSource/codDicomWebServerWrapper.js
+++ b/extensions/default/src/DicomWebDataSource/codDicomWebServerWrapper.js
@@ -230,9 +230,11 @@ class CodDicomWebServerClient {
       studyFound = this._findStudy(this._studiesMetadata, { StudyInstanceUID: studyInstanceUID });
     }
 
+    const seriesUID = queryParams?.SeriesInstanceUID;
+    const seriesUIDs = seriesUID ? (Array.isArray(seriesUID) ? seriesUID : [seriesUID]) : [];
     // In COD format, the DeidSeriesInstanceUID is used to identify series instead of SeriesInstanceUID.
-    const seriesFound = studyFound?.series.find(
-      ({ deidSeriesInstanceUID }) => deidSeriesInstanceUID === queryParams?.SeriesInstanceUID
+    const seriesFound = studyFound?.series.find(({ deidSeriesInstanceUID }) =>
+      seriesUIDs.includes(deidSeriesInstanceUID)
     );
 
     return new Promise(resolve => {

--- a/extensions/default/src/DicomWebDataSource/getCodImageId.js
+++ b/extensions/default/src/DicomWebDataSource/getCodImageId.js
@@ -21,7 +21,7 @@ export default function getCodImageId({ instance, frame, config }) {
     wadoRsImageId = getWADORSImageId(instance, config, frame);
   }
 
-  if (config.useURLParams && !instance.imageId && instance.BucketPath) {
+  if (config.useURLParams && (!instance.imageId || frame) && instance.BucketPath) {
     wadoRsImageId = wadoRsImageId.replace(
       config.wadoRoot,
       `${config.wadoRoot}/${instance.BucketPath}`

--- a/extensions/default/src/DicomWebDataSource/retrieveStudyMetadata.js
+++ b/extensions/default/src/DicomWebDataSource/retrieveStudyMetadata.js
@@ -38,7 +38,7 @@ export function retrieveStudyMetadata(
     throw new Error(`${moduleName}: Required 'StudyInstanceUID' parameter not provided.`);
   }
 
-  const promiseId = `${dicomWebConfig.name}:${StudyInstanceUID}`;
+  const promiseId = `${dicomWebConfig.name}:${StudyInstanceUID}:${filters?.seriesInstanceUID?.toString() || 'NO-SERIES-FILTER'}`;
 
   // Already waiting on result? Return cached promise
   if (StudyMetaDataPromises.has(promiseId)) {

--- a/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
+++ b/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
@@ -536,7 +536,7 @@ function _mapDisplaySets(displaySets, displaySetLoadingState, thumbnailImageSrcM
         countIcon: ds.countIcon,
         messages: ds.messages,
         StudyInstanceUID: ds.StudyInstanceUID,
-        SeriesInstanceUID: ds.SeriesInstanceUID,
+        DeidSeriesInstanceUID: ds.instance.DeidSeriesInstanceUID,
         componentType,
         imageSrc: thumbnailSrc || thumbnailImageSrcMap[displaySetInstanceUID],
         dragData: {

--- a/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
+++ b/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
@@ -536,6 +536,7 @@ function _mapDisplaySets(displaySets, displaySetLoadingState, thumbnailImageSrcM
         countIcon: ds.countIcon,
         messages: ds.messages,
         StudyInstanceUID: ds.StudyInstanceUID,
+        SeriesInstanceUID: ds.SeriesInstanceUID,
         componentType,
         imageSrc: thumbnailSrc || thumbnailImageSrcMap[displaySetInstanceUID],
         dragData: {

--- a/extensions/default/src/commandsModule.ts
+++ b/extensions/default/src/commandsModule.ts
@@ -628,11 +628,11 @@ const commandsModule = ({
       setTimeout(() => actions.scrollActiveThumbnailIntoView(), 0);
     },
 
-    downloadSeriesFile: ({ displaySetInstanceUID }) => {
+    downloadSeriesFile: async ({ displaySetInstanceUID }) => {
       const displaySet = displaySetService.getDisplaySetByUID(displaySetInstanceUID);
       const codServer = internal.getWadoRsWebServer();
       const deidSeriesInstanceUID = displaySet.instance.DeidSeriesInstanceUID;
-      const seriesDownloaded = codServer.downloadSeriesFile(deidSeriesInstanceUID);
+      const seriesDownloaded = await codServer.downloadSeriesFile(deidSeriesInstanceUID);
 
       uiNotificationService.show({
         title: 'Download Series file',

--- a/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
@@ -110,7 +110,7 @@ export default function PanelStudyBrowserTracking({
           countIcon: ds.countIcon,
           messages: ds.messages,
           StudyInstanceUID: ds.StudyInstanceUID,
-          SeriesInstanceUID: ds.SeriesInstanceUID,
+          DeidSeriesInstanceUID: ds.instance.DeidSeriesInstanceUID,
           componentType,
           imageSrc: thumbnailSrc || thumbnailImageSrcMap[displaySetInstanceUID],
           dragData: {

--- a/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
@@ -110,6 +110,7 @@ export default function PanelStudyBrowserTracking({
           countIcon: ds.countIcon,
           messages: ds.messages,
           StudyInstanceUID: ds.StudyInstanceUID,
+          SeriesInstanceUID: ds.SeriesInstanceUID,
           componentType,
           imageSrc: thumbnailSrc || thumbnailImageSrcMap[displaySetInstanceUID],
           dragData: {

--- a/modes/longitudinal/src/index.ts
+++ b/modes/longitudinal/src/index.ts
@@ -237,8 +237,8 @@ function modeFactory({ modeConfiguration }) {
             props: {
               leftPanels: [tracked.thumbnailList],
               leftPanelResizable: true,
-              rightPanels: [cornerstone.segmentation, tracked.measurements, gradienthealth.form],
-              rightPanelClosed: true,
+              rightPanels: [gradienthealth.form, cornerstone.segmentation, tracked.measurements],
+              rightPanelClosed: false,
               rightPanelResizable: true,
               viewports: [
                 {

--- a/modes/segmentation/src/index.tsx
+++ b/modes/segmentation/src/index.tsx
@@ -115,6 +115,11 @@ function modeFactory({ modeConfiguration }) {
         'Shapes',
       ]);
       toolbarService.createButtonSection('brushToolsSection', ['Brush', 'Eraser', 'Threshold']);
+      // Making the 'cornerstone.panelTool' the default/first right panel will automaically
+      // handle the evaluate functions for segmentation panel tools through the toolbox components.
+      // But since we changed the order, we need to call this here to handle the evaluate functions.
+      const sectionToolProps = toolbarService.getButtonPropsInButtonSection('segmentationToolbox');
+      sectionToolProps.forEach(props => toolbarService.handleEvaluateNested(props));
 
       customizationService.setCustomizations({
         'panelSegmentation.tableMode': {
@@ -195,7 +200,7 @@ function modeFactory({ modeConfiguration }) {
             props: {
               leftPanels: [ohif.leftPanel],
               leftPanelResizable: true,
-              rightPanels: [cornerstone.panelTool, cornerstone.measurements, gradienthealth.form],
+              rightPanels: [gradienthealth.form, cornerstone.panelTool, cornerstone.measurements],
               rightPanelResizable: true,
               // leftPanelClosed: true,
               viewports: [

--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -52,6 +52,8 @@ export async function defaultRouteInit(
     function ({ StudyInstanceUID, SeriesInstanceUID, madeInClient = false }) {
       const seriesMetadata = DicomMetadataStore.getSeries(StudyInstanceUID, SeriesInstanceUID);
 
+      /* The 'series filter failed' notification is out of context in
+      some sheet-integrated scenarios, so disabling it temporarily.
       // checks if the series filter was used, if it exists
       const seriesInstanceUIDs = filters?.seriesInstanceUID;
       if (
@@ -68,6 +70,7 @@ export async function defaultRouteInit(
           duration: 7000,
         });
       }
+      */
 
       displaySetService.makeDisplaySets(seriesMetadata.instances, { madeInClient });
     }

--- a/platform/core/src/utils/createStudyBrowserTabs.ts
+++ b/platform/core/src/utils/createStudyBrowserTabs.ts
@@ -34,7 +34,9 @@ export function createStudyBrowserTabs(
 
   studyDisplayList.forEach(study => {
     const displaySetsForStudy = displaySets.filter(
-      ds => ds.StudyInstanceUID === study.studyInstanceUid
+      ds =>
+        ds.StudyInstanceUID === study.studyInstanceUid &&
+        (!seriesUIdsToFilter.length || seriesUIdsToFilter.includes(ds.SeriesInstanceUID))
     );
 
     // sort them by seriesInstanceUID

--- a/platform/core/src/utils/createStudyBrowserTabs.ts
+++ b/platform/core/src/utils/createStudyBrowserTabs.ts
@@ -36,7 +36,7 @@ export function createStudyBrowserTabs(
     const displaySetsForStudy = displaySets.filter(
       ds =>
         ds.StudyInstanceUID === study.studyInstanceUid &&
-        (!seriesUIdsToFilter.length || seriesUIdsToFilter.includes(ds.SeriesInstanceUID))
+        (!seriesUIdsToFilter.length || seriesUIdsToFilter.includes(ds.DeidSeriesInstanceUID))
     );
 
     // sort them by seriesInstanceUID

--- a/yarn.lock
+++ b/yarn.lock
@@ -7806,10 +7806,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-cod-dicomweb-server@^1.3.11:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.11.tgz#a8e0d0111ac890bd5651887a1deaaa6f4bcdb17f"
-  integrity sha512-HqcshVYzt4dWAKZjEsK+QYSE3vqJ4L5xXqCklDmGyQhRyANDN3Y6MedM3K9WBhl+Utw9qvenrLc+lbGrjt3L0A==
+cod-dicomweb-server@^1.3.12:
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.12.tgz#3e84e6e0b8e9b3e649524fb11f7d47ecb1ae86f9"
+  integrity sha512-X56eSXhlpMkL+Wki24cx1KtC06xD+Qf47jWNJ6F6AvMsyjVg57PhQ8nSu1vmAVAHOfKRfGZMV6BGfWwAeMWsQQ==
   dependencies:
     comlink "^4.4.2"
     dicom-parser "^1.8.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7806,10 +7806,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-cod-dicomweb-server@^1.3.12:
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.12.tgz#3e84e6e0b8e9b3e649524fb11f7d47ecb1ae86f9"
-  integrity sha512-X56eSXhlpMkL+Wki24cx1KtC06xD+Qf47jWNJ6F6AvMsyjVg57PhQ8nSu1vmAVAHOfKRfGZMV6BGfWwAeMWsQQ==
+cod-dicomweb-server@^1.3.13:
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.13.tgz#da716dcd89c8c7eca14fa9047fe29a39b7c5a261"
+  integrity sha512-eqPtvVkx6ZOykGfJKMzG3sTbULhOjSgjBpZSCW+BrUItU4WoK7eO11MdVMQUiTwd7YlCW2jSingD6/2dvkIl1A==
   dependencies:
     comlink "^4.4.2"
     dicom-parser "^1.8.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7806,10 +7806,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-cod-dicomweb-server@^1.3.15:
-  version "1.3.15"
-  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.15.tgz#b1d1a9f89ba05621b5dd581a0f7892b8cd9b454e"
-  integrity sha512-+Tv4LQN/BX6xyRdGG7ta+8ZVpGkbt1cv8c1owRbTszawwpK7C7hkK8SY+nW6e2/iHB2zqLXanW9rd5o352qQYQ==
+cod-dicomweb-server@^1.3.16:
+  version "1.3.16"
+  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.16.tgz#8a1b256b36a962917836bb5e61e67e333bf6d9ae"
+  integrity sha512-tHzDzAp7SkswGo3za1ntU1GDcahGaSbTlTg4nIPQprWn+uldg+UmQFGvGVjaBluDMbPOd5NUgIYYTZ2lOiCboA==
   dependencies:
     comlink "^4.4.2"
     dicom-parser "^1.8.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7806,10 +7806,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-cod-dicomweb-server@^1.3.13:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.13.tgz#da716dcd89c8c7eca14fa9047fe29a39b7c5a261"
-  integrity sha512-eqPtvVkx6ZOykGfJKMzG3sTbULhOjSgjBpZSCW+BrUItU4WoK7eO11MdVMQUiTwd7YlCW2jSingD6/2dvkIl1A==
+cod-dicomweb-server@^1.3.14:
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.14.tgz#93b4906f3d36f83bfbdeb6f1b9891afefede7c50"
+  integrity sha512-4/GlnzGTIa/w0v3qMxU6hHKuixQz+GhArTNaNPY2XXUu7IaGheSWd1EzXT3wV7a7NdK1IVAUJzelQ0xXEiUCIg==
   dependencies:
     comlink "^4.4.2"
     dicom-parser "^1.8.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7806,10 +7806,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-cod-dicomweb-server@^1.3.14:
-  version "1.3.14"
-  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.14.tgz#93b4906f3d36f83bfbdeb6f1b9891afefede7c50"
-  integrity sha512-4/GlnzGTIa/w0v3qMxU6hHKuixQz+GhArTNaNPY2XXUu7IaGheSWd1EzXT3wV7a7NdK1IVAUJzelQ0xXEiUCIg==
+cod-dicomweb-server@^1.3.15:
+  version "1.3.15"
+  resolved "https://registry.yarnpkg.com/cod-dicomweb-server/-/cod-dicomweb-server-1.3.15.tgz#b1d1a9f89ba05621b5dd581a0f7892b8cd9b454e"
+  integrity sha512-+Tv4LQN/BX6xyRdGG7ta+8ZVpGkbt1cv8c1owRbTszawwpK7C7hkK8SY+nW6e2/iHB2zqLXanW9rd5o352qQYQ==
   dependencies:
     comlink "^4.4.2"
     dicom-parser "^1.8.21"


### PR DESCRIPTION
* Support for updated review sheet template.
  * Updated the series filtering to work with the new review sheet.

* Made the right form panel open by default when launching the viewer( in `viewer` and `segmentation` modes ).

* OPFS management tool improvements
  * Added manual purge dropdown to delete OPFS files older than a specific time.
  * Displayed total file size under the table( bottom-center ).
  * Displayed the collective file size of selected rows next to the selected rows count( bottom-left ).
  * Fixed the issue with StudyDescription not included in the global search.
  * Fixed the issue with LastUpdated using the formatted value for sorting.

* Added UserProject header to segmentation requests.

* Bug fixes and optimisation.

* Bug fixes and optimisation in [cod-dicomweb-server](https://github.com/gradienthealth/cod-dicomweb-server) package.

> Associated PRs
> * [GradientExtensionsAndModes](https://github.com/gradienthealth/GradientExtensionsAndModes/pull/20)
> * [cornerstone3D-beta](https://github.com/gradienthealth/cornerstone3D-beta/pull/23)