### PR TITLE
Gradienthealth/handle invalid series instance uid query param

### DIFF
--- a/platform/app/public/config/gradient_production.js
+++ b/platform/app/public/config/gradient_production.js
@@ -36,7 +36,7 @@ window.config = {
         'profile',
         'openid',
         'https://www.googleapis.com/auth/spreadsheets',
-        'https://www.googleapis.com/auth/devstorage.read_only',
+        'https://www.googleapis.com/auth/devstorage.read_write',
         'https://www.googleapis.com/auth/bigquery.readonly',
         'https://www.googleapis.com/auth/drive.metadata.readonly',
         'https://www.googleapis.com/auth/drive.readonly',

--- a/platform/core/src/utils/createStudyBrowserTabs.ts
+++ b/platform/core/src/utils/createStudyBrowserTabs.ts
@@ -68,6 +68,33 @@ export function createStudyBrowserTabs(
       }
     });
 
+    // If there are series uids to filter and there are no displaysets after the filtering,
+    // that means the series uids to filter is invalid.
+    // In this case, the Viewer will display all the series in the study in the viewport.
+    // So we will also display all the series in the study in the study browser panel( left panel ).
+    if (
+      seriesUIdsToFilter.length &&
+      !sortedDisplaySets.length &&
+      (displaySets.some(ds => ds.StudyInstanceUID === study.studyInstanceUid) ||
+        omittedSeries.some(os => os.studyInstanceUID === study.studyInstanceUid))
+    ) {
+      sortedDisplaySets.push(
+        ...displaySets.filter(ds => ds.StudyInstanceUID === study.studyInstanceUid)
+      );
+
+      omittedSeries.forEach(aOmittedSeries => {
+        if (aOmittedSeries.studyInstanceUID === study.studyInstanceUid) {
+          sortedDisplaySets.push({
+            StudyInstanceUID: study.studyInstanceUid,
+            SeriesInstanceUID: aOmittedSeries.seriesInstanceUID,
+            componentType: 'thumbnailNoImage',
+            description: aOmittedSeries.seriesInstanceUID,
+            messages: { size: () => 1, messages: [{ text: aOmittedSeries.error }] },
+          });
+        }
+      });
+    }
+
     const tabStudy = Object.assign({}, study, {
       displaySets: sortedDisplaySets,
     });


### PR DESCRIPTION
* Handled the invalid SeriesInstanceUIDs query param values.
* Changed the devstorage scope to `read_write` in production to save segmentations in the cloud.