### PR TITLE
Support for PHI Recording

### DIFF
--- a/extensions/cornerstone/src/initCornerstoneTools.js
+++ b/extensions/cornerstone/src/initCornerstoneTools.js
@@ -52,6 +52,7 @@ import * as polySeg from '@cornerstonejs/polymorphic-segmentation';
 import CalibrationLineTool from './tools/CalibrationLineTool';
 import ImageOverlayViewerTool from './tools/ImageOverlayViewerTool';
 import SmartStackScrollTool from './tools/SmartStackScrollTool';
+import PHIBoundingBoxTool from './tools/PHIBoundingBoxTool';
 
 export default function initCornerstoneTools(configuration = {}) {
   CrosshairsTool.isAnnotation = false;
@@ -119,6 +120,7 @@ export default function initCornerstoneTools(configuration = {}) {
   addTool(SplineContourSegmentationTool);
   addTool(LabelMapEditWithContourTool);
   addTool(SmartStackScrollTool);
+  addTool(PHIBoundingBoxTool);
   // Modify annotation tools to use dashed lines on SR
   const annotationStyle = {
     textBoxFontSize: '15px',
@@ -183,6 +185,7 @@ const toolNames = {
   SplineContourSegmentation: SplineContourSegmentationTool.toolName,
   LabelMapEditWithContourTool: LabelMapEditWithContourTool.toolName,
   SmartStackScroll: SmartStackScrollTool.toolName,
+  PHIBoundingBox: PHIBoundingBoxTool.toolName,
 };
 
 export { toolNames };

--- a/extensions/cornerstone/src/initMeasurementService.ts
+++ b/extensions/cornerstone/src/initMeasurementService.ts
@@ -33,6 +33,7 @@ const initMeasurementService = (
     Angle,
     CobbAngle,
     RectangleROI,
+    PHIBoundingBox,
     PlanarFreehandROI,
     SplineROI,
     LivewireContour,
@@ -126,6 +127,14 @@ const initMeasurementService = (
     RectangleROI.matchingCriteria,
     RectangleROI.toAnnotation,
     RectangleROI.toMeasurement
+  );
+
+  measurementService.addMapping(
+    csTools3DVer1MeasurementSource,
+    'PHIBoundingBox',
+    PHIBoundingBox.matchingCriteria,
+    PHIBoundingBox.toAnnotation,
+    PHIBoundingBox.toMeasurement
   );
 
   measurementService.addMapping(

--- a/extensions/cornerstone/src/tools/PHIBoundingBoxTool.ts
+++ b/extensions/cornerstone/src/tools/PHIBoundingBoxTool.ts
@@ -1,6 +1,8 @@
 import { RectangleROITool } from '@cornerstonejs/tools';
 
 class PHIBoundingBoxTool extends RectangleROITool {
+  static toolName = 'PHIBoundingBox';
+
   constructor(
     toolProps = {},
     defaultToolProps = {
@@ -11,5 +13,4 @@ class PHIBoundingBoxTool extends RectangleROITool {
   }
 }
 
-PHIBoundingBoxTool.toolName = 'PHIBoundingBox';
 export default PHIBoundingBoxTool;

--- a/extensions/cornerstone/src/tools/PHIBoundingBoxTool.ts
+++ b/extensions/cornerstone/src/tools/PHIBoundingBoxTool.ts
@@ -1,0 +1,15 @@
+import { RectangleROITool } from '@cornerstonejs/tools';
+
+class PHIBoundingBoxTool extends RectangleROITool {
+  constructor(
+    toolProps = {},
+    defaultToolProps = {
+      configuration: { getTextLines: () => ['PHI Bounding Box'] },
+    }
+  ) {
+    super(toolProps, defaultToolProps);
+  }
+}
+
+PHIBoundingBoxTool.toolName = 'PHIBoundingBox';
+export default PHIBoundingBoxTool;

--- a/extensions/cornerstone/src/tools/SmartStackScrollTool.ts
+++ b/extensions/cornerstone/src/tools/SmartStackScrollTool.ts
@@ -2,6 +2,8 @@ import { getEnabledElement, getEnabledElementByIds } from '@cornerstonejs/core';
 import { StackScrollTool, Types } from '@cornerstonejs/tools';
 
 class SmartStackScrollTool extends StackScrollTool {
+  static toolName = 'SmartStackScroll';
+
   parentDragCallback: (evt: Types.EventTypes.InteractionEventType) => void;
   parentMouseWheelCallback: (evt: Types.EventTypes.MouseWheelEventType) => void;
 
@@ -45,5 +47,4 @@ class SmartStackScrollTool extends StackScrollTool {
   }
 }
 
-SmartStackScrollTool.toolName = 'SmartStackScroll';
 export default SmartStackScrollTool;

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/constants/supportedTools.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/constants/supportedTools.js
@@ -8,6 +8,7 @@ const supportedTools = [
   'CobbAngle',
   'Probe',
   'RectangleROI',
+  'PHIBoundingBox',
   'PlanarFreehandROI',
   'SplineROI',
   'LivewireContour',

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/measurementServiceMappingsFactory.ts
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/measurementServiceMappingsFactory.ts
@@ -166,6 +166,22 @@ const measurementServiceMappingsFactory = (
         },
       ],
     },
+    PHIBoundingBox: {
+      toAnnotation: RectangleROI.toAnnotation,
+      toMeasurement: csToolsAnnotation =>
+        RectangleROI.toMeasurement(
+          csToolsAnnotation,
+          displaySetService,
+          cornerstoneViewportService,
+          _getValueTypeFromToolType,
+          customizationService
+        ),
+      matchingCriteria: [
+        {
+          valueType: MeasurementService.VALUE_TYPES.POLYLINE,
+        },
+      ],
+    },
     PlanarFreehandROI: {
       toAnnotation: PlanarFreehandROI.toAnnotation,
       toMeasurement: csToolsAnnotation =>

--- a/extensions/measurement-tracking/src/index.tsx
+++ b/extensions/measurement-tracking/src/index.tsx
@@ -1,4 +1,4 @@
-import getContextModule from './getContextModule';
+import getContextModule, { useTrackedMeasurements } from './getContextModule';
 import getPanelModule from './getPanelModule';
 import getViewportModule from './getViewportModule';
 import { id } from './id.js';
@@ -51,6 +51,16 @@ const measurementTrackingExtension = {
     });
   },
   getCustomizationModule,
+  getUtilityModule() {
+    return [
+      {
+        name: 'measurement-tracking',
+        exports: {
+          useTrackedMeasurements,
+        },
+      },
+    ];
+  },
 };
 
 export default measurementTrackingExtension;

--- a/modes/basic/src/index.tsx
+++ b/modes/basic/src/index.tsx
@@ -275,6 +275,8 @@ export const toolbarSections = {
     'SegmentLabelTool',
     'OPFSTool',
   ],
+
+  PHIBoundingBox: ['PHIBoundingBox'],
 };
 
 export const basicLayout = {

--- a/modes/basic/src/initToolGroups.ts
+++ b/modes/basic/src/initToolGroups.ts
@@ -70,6 +70,7 @@ function initDefaultToolGroup(extensionManager, toolGroupService, commandsManage
       { toolName: toolNames.EllipticalROI },
       { toolName: toolNames.CircleROI },
       { toolName: toolNames.RectangleROI },
+      { toolName: toolNames.PHIBoundingBox },
       {
         toolName: toolNames.SmartStackScroll,
         bindings: [
@@ -231,6 +232,7 @@ function initMPRToolGroup(extensionManager, toolGroupService, commandsManager) {
       { toolName: toolNames.EllipticalROI },
       { toolName: toolNames.CircleROI },
       { toolName: toolNames.RectangleROI },
+      { toolName: toolNames.PHIBoundingBox },
       { toolName: toolNames.StackScroll },
       { toolName: toolNames.Angle },
       { toolName: toolNames.CobbAngle },

--- a/modes/basic/src/toolbarButtons.ts
+++ b/modes/basic/src/toolbarButtons.ts
@@ -519,6 +519,17 @@ const toolbarButtons: Button[] = [
     },
   },
   {
+    id: 'PHIBoundingBox',
+    uiType: 'ohif.toolButton',
+    props: {
+      icon: 'tool-rectangle',
+      label: i18n.t('Buttons:PHIBoundingBox'),
+      tooltip: i18n.t('Buttons:PHI BoundingBox'),
+      commands: setToolActiveToolbar,
+      evaluate: 'evaluate.cornerstoneTool',
+    },
+  },
+  {
     id: 'CircleROI',
     uiType: 'ohif.toolButton',
     props: {

--- a/modes/segmentation/src/index.tsx
+++ b/modes/segmentation/src/index.tsx
@@ -147,6 +147,8 @@ function modeFactory({ modeConfiguration }) {
 
       toolbarService.updateSection('BrushTools', ['Brush', 'Eraser', 'Threshold']);
 
+      toolbarService.updateSection('PHIBoundingBox', ['PHIBoundingBox']);
+
       // Making the 'cornerstone.panelTool' the default/first right panel will automaically
       // handle the evaluate functions for segmentation panel tools through the toolbox components.
       // But since we changed the order, we need to call this here to handle the evaluate functions.

--- a/modes/segmentation/src/initToolGroups.ts
+++ b/modes/segmentation/src/initToolGroups.ts
@@ -171,6 +171,7 @@ function createTools({ utilityModule, commandsManager }) {
           },
         },
       },
+      { toolName: toolNames.PHIBoundingBox },
     ],
     disabled: [{ toolName: toolNames.ReferenceLines }, { toolName: toolNames.AdvancedMagnify }],
   };

--- a/modes/segmentation/src/toolbarButtons.ts
+++ b/modes/segmentation/src/toolbarButtons.ts
@@ -1207,6 +1207,17 @@ export const toolbarButtons: Button[] = [
       commands: 'showOPFSManagementTool',
     },
   },
+  {
+    id: 'PHIBoundingBox',
+    uiType: 'ohif.toolButton',
+    props: {
+      icon: 'tool-rectangle',
+      label: i18n.t('Buttons:PHIBoundingBox'),
+      tooltip: i18n.t('Buttons:PHI BoundingBox'),
+      commands: setToolActiveToolbar,
+      evaluate: 'evaluate.cornerstoneTool',
+    },
+  },
 ];
 
 export default toolbarButtons;

--- a/platform/app/public/config/gradient.js
+++ b/platform/app/public/config/gradient.js
@@ -10,7 +10,7 @@ window.config = {
   showStudyList: true,
   // some windows systems have issues with more than 3 web workers
   maxNumberOfWebWorkers: 3,
-
+  measurementTrackingMode: 'simplified',
   // below flag is for performance reasons, but it might not work for all servers
   omitQuotationForMultipartRequest: true,
   showWarningMessageForCrossOrigin: true,

--- a/platform/app/public/config/gradient_production.js
+++ b/platform/app/public/config/gradient_production.js
@@ -10,7 +10,7 @@ window.config = {
   showStudyList: true,
   // some windows systems have issues with more than 3 web workers
   maxNumberOfWebWorkers: 3,
-
+  measurementTrackingMode: 'simplified',
   // below flag is for performance reasons, but it might not work for all servers
   omitQuotationForMultipartRequest: true,
   showWarningMessageForCrossOrigin: true,


### PR DESCRIPTION
### Support for recording and persisting PHI bounding box coordinates while reviewing study/ series from the sheet.
* Created PHIBoundingBoxTool and added it to a new button section.
* Added the tool in longitudinal and segmentation modes.
* Enabled the 'simplified' measurement tracking mode to track measurements in longitudinal mode automatically.