### PR TITLE
Add URL params to control side panel state

### DIFF
--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -156,6 +156,16 @@ export default function ModeRoute({
         // layoutProps contains all props but leftPanels and rightPanels
         layoutData.props = layoutProps;
 
+        // Allow URL params to override panel closed state
+        const urlLeftPanelClosed = lowerCaseSearchParams.get('leftpanelclosed');
+        const urlRightPanelClosed = lowerCaseSearchParams.get('rightpanelclosed');
+        if (urlLeftPanelClosed !== null) {
+          layoutData.props.leftPanelClosed = urlLeftPanelClosed === 'true';
+        }
+        if (urlRightPanelClosed !== null) {
+          layoutData.props.rightPanelClosed = urlRightPanelClosed === 'true';
+        }
+
         layoutTemplateData.current = layoutData;
         setRefresh(!refresh);
       }


### PR DESCRIPTION
## Motivation
We're building a review service prototype that embeds the Gradient viewer in an iframe. In this context, the viewer always displays a single study/series selected from the review UI — so the left study list panel is redundant, and the right Google Sheets panel is not needed (the review service itself provides the review workflow). Having both panels open by default wastes screen real estate and requires the reviewer to manually close them every time a new series loads.

Rather than changing mode-level defaults (which would affect all viewer users), this adds URL parameter support so embedding consumers can control panel state per-load.

## Summary
- Adds support for `leftPanelClosed` and `rightPanelClosed` URL query parameters that override the mode's default panel open/closed state
- Non-breaking: modes that don't pass these params behave exactly as before

## Usage
```
/viewer/datasource/mode?StudyInstanceUIDs=...&leftPanelClosed=true&rightPanelClosed=true
```

## Test plan
- [ ] Load viewer normally (no new params) — panels should open/close per mode defaults
- [ ] Load with `?leftPanelClosed=true` — left panel (study list) should start closed
- [ ] Load with `?rightPanelClosed=true` — right panel should start closed
- [ ] Load with both params set to `true` — both panels closed
- [ ] Load with params set to `false` — panels open (overrides mode defaults if mode closes them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)