### PR TITLE
Added support for URL study/ series UIDs filtering in Viewport overlay menu

### DIFF
--- a/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/ViewportDataOverlayMenu.tsx
+++ b/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/ViewportDataOverlayMenu.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { useViewportDisplaySets } from '../../hooks/useViewportDisplaySets';
 import SelectItemWithModality from '../SelectItemWithModality';
 import { useViewportRendering } from '../../hooks';
+import { customDisplaySetFilterFn } from './utils';
 
 function ViewportDataOverlayMenu({ viewportId }: withAppTypes<{ viewportId: string }>) {
   const { commandsManager, servicesManager } = useSystem();
@@ -36,7 +37,7 @@ function ViewportDataOverlayMenu({ viewportId }: withAppTypes<{ viewportId: stri
     potentialBackgroundDisplaySets,
     overlayDisplaySets,
     foregroundDisplaySets,
-  } = useViewportDisplaySets(viewportId);
+  } = useViewportDisplaySets(viewportId, { displaySetFilterFn: customDisplaySetFilterFn });
 
   const [optimisticOverlayDisplaySets, setOptimisticOverlayDisplaySets] =
     useState(overlayDisplaySets);

--- a/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
+++ b/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
@@ -162,3 +162,17 @@ export function getAvailableSegmentations(segmentationService) {
     frameOfReferenceUID: segmentation.frameOfReferenceUID,
   }));
 }
+
+/**
+ * Filters the displaysets based on the Study and Series UIDs in the URL params
+ */
+export function customDisplaySetFilterFn(displaySet: AppTypes.DisplaySet) {
+  const params = new URLSearchParams(window.location.search);
+  const deidStudyUIDs = params.getAll('StudyInstanceUIDs');
+  const deidSeriesUIDs = params.getAll('SeriesInstanceUIDs');
+
+  const studyMatched = deidStudyUIDs.includes(displaySet.instance?.DeidStudyInstanceUID);
+  const seriesMatched = deidSeriesUIDs.includes(displaySet.instance?.DeidSeriesInstanceUID);
+
+  return studyMatched && (!deidSeriesUIDs.length || seriesMatched);
+}

--- a/extensions/cornerstone/src/hooks/useViewportDisplaySets.ts
+++ b/extensions/cornerstone/src/hooks/useViewportDisplaySets.ts
@@ -42,6 +42,10 @@ export type UseViewportDisplaySetsOptions = {
    * Whether to include potential background display sets
    */
   includePotentialBackground?: boolean;
+  /**
+   * A filter function to filter the displaysets at the start
+   */
+  displaySetFilterFn?: (displayset: AppTypes.DisplaySet) => boolean;
 };
 
 /**
@@ -111,14 +115,20 @@ export function useViewportDisplaySets(
     includePotentialOverlay = true,
     includePotentialForeground = true,
     includePotentialBackground = true,
+    displaySetFilterFn = null,
   } = options || {};
 
   // Get all available display sets (only if needed)
   const needsAllDisplaySets = includePotentialBackground;
-  const allDisplaySets = useMemo(
-    () => (needsAllDisplaySets ? displaySetService.getActiveDisplaySets() : []),
-    [displaySetService, needsAllDisplaySets]
-  );
+  const allDisplaySets = useMemo(() => {
+    if (!needsAllDisplaySets) {
+      return [];
+    }
+
+    const activeDisplaySets = displaySetService.getActiveDisplaySets();
+
+    return displaySetFilterFn ? activeDisplaySets.filter(displaySetFilterFn) : activeDisplaySets;
+  }, [displaySetService, needsAllDisplaySets, displaySetFilterFn]);
 
   // Get all available segmentations (only if needed)
   const needsSegmentations = includeOverlay;


### PR DESCRIPTION
* Added support for optional displayset filtering in `useViewportDisplaySets()` hook.
* Added URL params study/ series UIDs filtering in Viewport overlay menu