### PR TITLE
DQ-294 - Add postMessage bridge for series switching without SPA reload

### DIFF
--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -13,6 +13,25 @@ import { updateAuthServiceAndCleanUrl } from './updateAuthServiceAndCleanUrl';
 
 const { getSplitParam } = utils;
 
+/** Message sent by a parent frame to switch the displayed series without a full SPA reload. */
+interface LoadSeriesMessage {
+  type: 'loadSeries';
+  studyUID: string;
+  seriesUID: string;
+  institution: string;
+}
+
+function isLoadSeriesMessage(data: unknown): data is LoadSeriesMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as LoadSeriesMessage).type === 'loadSeries' &&
+    typeof (data as LoadSeriesMessage).studyUID === 'string' &&
+    typeof (data as LoadSeriesMessage).seriesUID === 'string' &&
+    typeof (data as LoadSeriesMessage).institution === 'string'
+  );
+}
+
 export default function ModeRoute({
   mode,
   dataSourceName,
@@ -141,15 +160,11 @@ export default function ModeRoute({
     const { viewportGridService, cineService } = servicesManager.services;
 
     async function handleMessage(event: MessageEvent) {
-      const { data } = event;
-      if (data?.type !== 'loadSeries') {
+      if (!isLoadSeriesMessage(event.data)) {
         return;
       }
 
-      const { studyUID, seriesUID, institution } = data;
-      if (!studyUID || !seriesUID || !institution) {
-        return;
-      }
+      const { studyUID, seriesUID, institution } = event.data;
 
       // Check if we already have display sets for this series (cache hit).
       let displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);

--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useParams, useLocation } from 'react-router';
 import PropTypes from 'prop-types';
-import { DicomMetadataStore, utils } from '@ohif/core';
+import { utils } from '@ohif/core';
 import { ImageViewerProvider, DragAndDropProvider } from '@ohif/ui-next';
 import { useSearchParams } from '../../hooks';
 import { useAppConfig } from '@state';
@@ -10,27 +10,9 @@ import Compose from './Compose';
 import loadModules from '../../pluginImports';
 import { defaultRouteInit } from './defaultRouteInit';
 import { updateAuthServiceAndCleanUrl } from './updateAuthServiceAndCleanUrl';
+import { usePostMessageSeriesSwitching } from './usePostMessageSeriesSwitching';
 
 const { getSplitParam } = utils;
-
-/** Message sent by a parent frame to switch the displayed series without a full SPA reload. */
-interface LoadSeriesMessage {
-  type: 'loadSeries';
-  studyUID: string;
-  seriesUID: string;
-  institution: string;
-}
-
-function isLoadSeriesMessage(data: unknown): data is LoadSeriesMessage {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    (data as LoadSeriesMessage).type === 'loadSeries' &&
-    typeof (data as LoadSeriesMessage).studyUID === 'string' &&
-    typeof (data as LoadSeriesMessage).seriesUID === 'string' &&
-    typeof (data as LoadSeriesMessage).institution === 'string'
-  );
-}
 
 export default function ModeRoute({
   mode,
@@ -149,71 +131,12 @@ export default function ModeRoute({
     };
   }, [location, ExtensionDependenciesLoaded]);
 
-  // postMessage bridge: allows a parent frame to switch the displayed series
-  // without a full SPA reload. Expects messages of the form:
-  //   { type: 'loadSeries', studyUID, seriesUID, institution }
-  useEffect(() => {
-    if (!ExtensionDependenciesLoaded) {
-      return;
-    }
-
-    const { viewportGridService, cineService } = servicesManager.services;
-
-    async function handleMessage(event: MessageEvent) {
-      if (!isLoadSeriesMessage(event.data)) {
-        return;
-      }
-
-      const { studyUID, seriesUID, institution } = event.data;
-
-      // Check if we already have display sets for this series (cache hit).
-      let displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);
-
-      if (!displaySets?.length) {
-        // Fetch metadata for the study from the correct GCS bucket.
-        const bucketName = `${institution}-pacs-deid`;
-        const bucketPrefix = 'v1.0/dicomweb';
-        await dataSource.retrieve.series.metadata({
-          StudyInstanceUID: studyUID,
-          returnPromises: false,
-          bucketDetails: {
-            buckets: [bucketName],
-            bucketPrefix,
-          },
-        });
-
-        displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);
-      }
-
-      if (!displaySets?.length) {
-        console.warn(`[postMessage] No display sets found for series ${seriesUID}`);
-        return;
-      }
-
-      const { activeViewportId } = viewportGridService.getState();
-
-      // Stop cine before swapping to avoid inconsistent state.
-      const cineState = cineService.getState();
-      const currentCine = cineState.cines?.[activeViewportId];
-      if (currentCine?.isPlaying) {
-        cineService.setCine({
-          id: activeViewportId,
-          frameRate: currentCine.frameRate ?? cineState.default?.frameRate ?? 24,
-          isPlaying: false,
-        });
-      }
-
-      viewportGridService.setDisplaySetsForViewports([
-        {
-          viewportId: activeViewportId,
-          displaySetInstanceUIDs: [displaySets[0].displaySetInstanceUID],
-        },
-      ]);
-    }
-
-    window.addEventListener('message', handleMessage);
-    return () => window.removeEventListener('message', handleMessage);
-  }, [ExtensionDependenciesLoaded, servicesManager, displaySetService, dataSource]);
+  usePostMessageSeriesSwitching({
+    enabled: ExtensionDependenciesLoaded,
+    servicesManager,
+    displaySetService,
+    dataSource,
+  });
 
   useEffect(() => {
     if (!ExtensionDependenciesLoaded || !studyInstanceUIDs?.length) {

--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useParams, useLocation } from 'react-router';
 import PropTypes from 'prop-types';
-import { utils } from '@ohif/core';
+import { DicomMetadataStore, utils } from '@ohif/core';
 import { ImageViewerProvider, DragAndDropProvider } from '@ohif/ui-next';
 import { useSearchParams } from '../../hooks';
 import { useAppConfig } from '@state';
@@ -129,6 +129,76 @@ export default function ModeRoute({
       layoutTemplateData.current = null;
     };
   }, [location, ExtensionDependenciesLoaded]);
+
+  // postMessage bridge: allows a parent frame to switch the displayed series
+  // without a full SPA reload. Expects messages of the form:
+  //   { type: 'loadSeries', studyUID, seriesUID, institution }
+  useEffect(() => {
+    if (!ExtensionDependenciesLoaded) {
+      return;
+    }
+
+    const { viewportGridService, cineService } = servicesManager.services;
+
+    async function handleMessage(event: MessageEvent) {
+      const { data } = event;
+      if (data?.type !== 'loadSeries') {
+        return;
+      }
+
+      const { studyUID, seriesUID, institution } = data;
+      if (!studyUID || !seriesUID || !institution) {
+        return;
+      }
+
+      // Check if we already have display sets for this series (cache hit).
+      let displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);
+
+      if (!displaySets?.length) {
+        // Fetch metadata for the study from the correct GCS bucket.
+        const bucketName = `${institution}-pacs-deid`;
+        const bucketPrefix = 'v1.0/dicomweb';
+        await dataSource.retrieve.series.metadata({
+          StudyInstanceUID: studyUID,
+          returnPromises: false,
+          bucketDetails: {
+            buckets: [bucketName],
+            bucketPrefix,
+          },
+        });
+
+        displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);
+      }
+
+      if (!displaySets?.length) {
+        console.warn(`[postMessage] No display sets found for series ${seriesUID}`);
+        return;
+      }
+
+      const { activeViewportId } = viewportGridService.getState();
+
+      // Stop cine before swapping to avoid inconsistent state.
+      const cineState = cineService.getState();
+      const currentCine = cineState.cines?.[activeViewportId];
+      if (currentCine?.isPlaying) {
+        cineService.setCine({
+          id: activeViewportId,
+          frameRate: currentCine.frameRate ?? cineState.default?.frameRate ?? 24,
+          isPlaying: false,
+        });
+      }
+
+      viewportGridService.setDisplaySetsForViewports([
+        {
+          viewportId: activeViewportId,
+          displaySetInstanceUIDs: [displaySets[0].displaySetInstanceUID],
+        },
+      ]);
+    }
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [ExtensionDependenciesLoaded, servicesManager, displaySetService, dataSource]);
 
   useEffect(() => {
     if (!ExtensionDependenciesLoaded || !studyInstanceUIDs?.length) {

--- a/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
+++ b/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
@@ -8,6 +8,13 @@ interface LoadSeriesMessage {
   institution: string;
 }
 
+/** Response posted back to the parent frame after a series switch attempt. */
+type SeriesLoadResponse =
+  | { type: 'seriesLoaded'; seriesUID: string }
+  | { type: 'seriesLoadError'; seriesUID: string; error: SeriesLoadErrorCode; detail?: string };
+
+type SeriesLoadErrorCode = 'METADATA_FETCH_FAILED' | 'SERIES_NOT_FOUND' | 'VIEWPORT_UPDATE_FAILED';
+
 function isLoadSeriesMessage(data: unknown): data is LoadSeriesMessage {
   return (
     typeof data === 'object' &&
@@ -44,6 +51,9 @@ export function usePostMessageSeriesSwitching({
     const { viewportGridService, cineService } = servicesManager.services;
 
     async function handleMessage(event: MessageEvent) {
+      function reply(response: SeriesLoadResponse) {
+        event.source?.postMessage(response, { targetOrigin: event.origin });
+      }
       if (!isLoadSeriesMessage(event.data)) {
         return;
       }
@@ -55,44 +65,66 @@ export function usePostMessageSeriesSwitching({
 
       if (!displaySets?.length) {
         // Fetch metadata for the study from the correct GCS bucket.
-        const bucketName = `${institution}-pacs-deid`;
-        const bucketPrefix = 'v1.0/dicomweb';
-        await dataSource.retrieve.series.metadata({
-          StudyInstanceUID: studyUID,
-          returnPromises: false,
-          bucketDetails: {
-            buckets: [bucketName],
-            bucketPrefix,
-          },
-        });
+        try {
+          const bucketName = `${institution}-pacs-deid`;
+          const bucketPrefix = 'v1.0/dicomweb';
+          await dataSource.retrieve.series.metadata({
+            StudyInstanceUID: studyUID,
+            returnPromises: false,
+            bucketDetails: {
+              buckets: [bucketName],
+              bucketPrefix,
+            },
+          });
+        } catch (err) {
+          reply({
+            type: 'seriesLoadError',
+            seriesUID,
+            error: 'METADATA_FETCH_FAILED',
+            detail: err instanceof Error ? err.message : String(err),
+          });
+          return;
+        }
 
         displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);
       }
 
       if (!displaySets?.length) {
-        console.warn(`[postMessage] No display sets found for series ${seriesUID}`);
+        reply({ type: 'seriesLoadError', seriesUID, error: 'SERIES_NOT_FOUND' });
         return;
       }
 
-      const { activeViewportId } = viewportGridService.getState();
+      try {
+        const { activeViewportId } = viewportGridService.getState();
 
-      // Stop cine before swapping to avoid inconsistent state.
-      const cineState = cineService.getState();
-      const currentCine = cineState.cines?.[activeViewportId];
-      if (currentCine?.isPlaying) {
-        cineService.setCine({
-          id: activeViewportId,
-          frameRate: currentCine.frameRate ?? cineState.default?.frameRate ?? 24,
-          isPlaying: false,
+        // Stop cine before swapping to avoid inconsistent state.
+        const cineState = cineService.getState();
+        const currentCine = cineState.cines?.[activeViewportId];
+        if (currentCine?.isPlaying) {
+          cineService.setCine({
+            id: activeViewportId,
+            frameRate: currentCine.frameRate ?? cineState.default?.frameRate ?? 24,
+            isPlaying: false,
+          });
+        }
+
+        viewportGridService.setDisplaySetsForViewports([
+          {
+            viewportId: activeViewportId,
+            displaySetInstanceUIDs: [displaySets[0].displaySetInstanceUID],
+          },
+        ]);
+      } catch (err) {
+        reply({
+          type: 'seriesLoadError',
+          seriesUID,
+          error: 'VIEWPORT_UPDATE_FAILED',
+          detail: err instanceof Error ? err.message : String(err),
         });
+        return;
       }
 
-      viewportGridService.setDisplaySetsForViewports([
-        {
-          viewportId: activeViewportId,
-          displaySetInstanceUIDs: [displaySets[0].displaySetInstanceUID],
-        },
-      ]);
+      reply({ type: 'seriesLoaded', seriesUID });
     }
 
     window.addEventListener('message', handleMessage);

--- a/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
+++ b/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
@@ -1,0 +1,101 @@
+import { useEffect } from 'react';
+
+/** Message sent by a parent frame to switch the displayed series without a full SPA reload. */
+interface LoadSeriesMessage {
+  type: 'loadSeries';
+  studyUID: string;
+  seriesUID: string;
+  institution: string;
+}
+
+function isLoadSeriesMessage(data: unknown): data is LoadSeriesMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as LoadSeriesMessage).type === 'loadSeries' &&
+    typeof (data as LoadSeriesMessage).studyUID === 'string' &&
+    typeof (data as LoadSeriesMessage).seriesUID === 'string' &&
+    typeof (data as LoadSeriesMessage).institution === 'string'
+  );
+}
+
+/**
+ * Listens for postMessage events from a parent frame to switch the displayed
+ * series without a full SPA reload. When display sets are already cached, swaps
+ * the viewport instantly. Otherwise fetches metadata from the correct GCS bucket
+ * before swapping.
+ */
+export function usePostMessageSeriesSwitching({
+  enabled,
+  servicesManager,
+  displaySetService,
+  dataSource,
+}: {
+  enabled: boolean;
+  servicesManager: AppTypes.ServicesManager;
+  displaySetService: AppTypes.DisplaySetService;
+  dataSource: any;
+}) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const { viewportGridService, cineService } = servicesManager.services;
+
+    async function handleMessage(event: MessageEvent) {
+      if (!isLoadSeriesMessage(event.data)) {
+        return;
+      }
+
+      const { studyUID, seriesUID, institution } = event.data;
+
+      // Check if we already have display sets for this series (cache hit).
+      let displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);
+
+      if (!displaySets?.length) {
+        // Fetch metadata for the study from the correct GCS bucket.
+        const bucketName = `${institution}-pacs-deid`;
+        const bucketPrefix = 'v1.0/dicomweb';
+        await dataSource.retrieve.series.metadata({
+          StudyInstanceUID: studyUID,
+          returnPromises: false,
+          bucketDetails: {
+            buckets: [bucketName],
+            bucketPrefix,
+          },
+        });
+
+        displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);
+      }
+
+      if (!displaySets?.length) {
+        console.warn(`[postMessage] No display sets found for series ${seriesUID}`);
+        return;
+      }
+
+      const { activeViewportId } = viewportGridService.getState();
+
+      // Stop cine before swapping to avoid inconsistent state.
+      const cineState = cineService.getState();
+      const currentCine = cineState.cines?.[activeViewportId];
+      if (currentCine?.isPlaying) {
+        cineService.setCine({
+          id: activeViewportId,
+          frameRate: currentCine.frameRate ?? cineState.default?.frameRate ?? 24,
+          isPlaying: false,
+        });
+      }
+
+      viewportGridService.setDisplaySetsForViewports([
+        {
+          viewportId: activeViewportId,
+          displaySetInstanceUIDs: [displaySets[0].displaySetInstanceUID],
+        },
+      ]);
+    }
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [enabled, servicesManager, displaySetService, dataSource]);
+}

--- a/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
+++ b/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
@@ -9,9 +9,13 @@ interface LoadSeriesMessage {
 }
 
 /** Response posted back to the parent frame after a series switch attempt. */
-type SeriesLoadResponse =
-  | { type: 'seriesLoaded'; seriesUID: string }
-  | { type: 'seriesLoadError'; seriesUID: string; error: SeriesLoadErrorCode; detail?: string };
+interface SeriesLoadResponse {
+  type: 'seriesLoadResponse';
+  success: boolean;
+  seriesUID: string;
+  error?: SeriesLoadErrorCode;
+  detail?: string;
+}
 
 type SeriesLoadErrorCode = 'METADATA_FETCH_FAILED' | 'SERIES_NOT_FOUND' | 'VIEWPORT_UPDATE_FAILED';
 
@@ -78,7 +82,8 @@ export function usePostMessageSeriesSwitching({
           });
         } catch (err) {
           reply({
-            type: 'seriesLoadError',
+            type: 'seriesLoadResponse',
+            success: false,
             seriesUID,
             error: 'METADATA_FETCH_FAILED',
             detail: err instanceof Error ? err.message : String(err),
@@ -90,7 +95,7 @@ export function usePostMessageSeriesSwitching({
       }
 
       if (!displaySets?.length) {
-        reply({ type: 'seriesLoadError', seriesUID, error: 'SERIES_NOT_FOUND' });
+        reply({ type: 'seriesLoadResponse', success: false, seriesUID, error: 'SERIES_NOT_FOUND' });
         return;
       }
 
@@ -116,7 +121,8 @@ export function usePostMessageSeriesSwitching({
         ]);
       } catch (err) {
         reply({
-          type: 'seriesLoadError',
+          type: 'seriesLoadResponse',
+          success: false,
           seriesUID,
           error: 'VIEWPORT_UPDATE_FAILED',
           detail: err instanceof Error ? err.message : String(err),
@@ -124,7 +130,7 @@ export function usePostMessageSeriesSwitching({
         return;
       }
 
-      reply({ type: 'seriesLoaded', seriesUID });
+      reply({ type: 'seriesLoadResponse', success: true, seriesUID });
     }
 
     window.addEventListener('message', handleMessage);


### PR DESCRIPTION
## Summary
- Add `usePostMessageSeriesSwitching` hook (new file alongside `Mode.tsx`) that listens for `LoadSeriesMessage` events from a parent frame
- When display sets are already cached (same study), swaps the viewport instantly
- For uncached series, fetches metadata from the correct GCS bucket via `bucketDetails` before swapping
- Posts a typed `SeriesLoadResponse` back to the parent frame with `success`, and `error`/`detail` on failure (`METADATA_FETCH_FAILED`, `SERIES_NOT_FOUND`, `VIEWPORT_UPDATE_FAILED`)
- Eliminates per-series SPA reload (~1-3s) when embedded in the review service
- Companion PR: https://github.com/gradienthealth/review-service/pull/72

## Test plan
- [ ] Load OHIF in an iframe with a study/series
- [ ] Send `postMessage({ type: 'loadSeries', studyUID, seriesUID, institution })` from parent
- [ ] Verify viewport switches to the new series without a full page reload
- [ ] Test switching to a series in a different study (metadata fetch should occur)
- [ ] Test switching to a series in a different institution (bucket switch should occur)
- [ ] Verify pixel data loads correctly after postMessage-based switch
- [ ] Verify `seriesLoadResponse` with `success: false` is posted back for a nonexistent series UID

🤖 Generated with [Claude Code](https://claude.com/claude-code)