### PR TITLE
DQ-312 - Reduce WebGL context pool from 7 to 1 for single-viewport viewer

### DIFF
--- a/extensions/cornerstone/src/init.tsx
+++ b/extensions/cornerstone/src/init.tsx
@@ -74,6 +74,7 @@ export default async function init({
     rendering: {
       ...cornerstone.getConfiguration().rendering,
       strictZSpacingForVolumeViewport: appConfig.strictZSpacingForVolumeViewport,
+      webGlContextCount: 1,
     },
   });
 


### PR DESCRIPTION
## Summary
- Reduce Cornerstone3D `webGlContextCount` from 7 (default) to 1 in the viewer init config
- Eliminates WebGL context eviction when embedding multiple OHIF iframes (e.g. for series pre-rendering in the review page)
- Matches what Cornerstone already does on mobile devices; risk-free for our single-viewport viewer

## Context
- We want to pre-render multiple `iframes` embedding the Gradient OHIF Viewer in [Review Service v2](https://github.com/gradienthealth/review-service)
- This will allow us to hide series download latency by instantly switching to a pre-fetched viewer `iframe`
- Right now, each viewer iframe uses 7 WebGL contexts (1 viewport + 6 pre-allocated pool slots for multi-viewport parallelization)
- Chrome enforces a hard limit of 16 WebGL contexts, so 2 iframes (14 contexts) is the max — additional `iframes` cause older ones to lose their rendering contexts and freeze
- Cranking the webGLContextCount down to 1 allows 6 or more concurrent Viewer iframes to be fully functional ([full experiment writeup](https://www.notion.so/338d8c90e19781c98d2efb1df32cfc42))
- There seems to be zero performance downside to this because our only use case (as far as I can tell - confirmation would be useful here) is single-viewport. Having additional contexts is only important for multi-viewport layouts, which we seem to have none of

## Test plan
- [ ] Verify single-viewport viewer renders correctly (no regression)
- [ ] Verify multiple embedded iframes can render simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)