### PR TITLE
DQ-313 - Add clearCache postMessage handler to purge Cornerstone image cache

### DIFF
--- a/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
+++ b/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
@@ -6,6 +6,7 @@ interface LoadSeriesMessage {
   studyUID: string;
   seriesUID: string;
   institution: string;
+  clearCache?: boolean;
 }
 
 /** Response posted back to the parent frame after a series switch attempt. */
@@ -58,11 +59,19 @@ export function usePostMessageSeriesSwitching({
       function reply(response: SeriesLoadResponse) {
         event.source?.postMessage(response, { targetOrigin: event.origin });
       }
+
       if (!isLoadSeriesMessage(event.data)) {
         return;
       }
 
-      const { studyUID, seriesUID, institution } = event.data;
+      const { studyUID, seriesUID, institution, clearCache = true } = event.data;
+
+      // Default true to avoid unbounded memory growth when the viewer is embedded
+      // via iframe and switched repeatedly via postMessage — without purging,
+      // Cornerstone retains decoded pixel data from every previously loaded series.
+      if (clearCache) {
+        (window as any).cornerstone?.cache?.purgeCache();
+      }
 
       // Check if we already have display sets for this series (cache hit).
       let displaySets = displaySetService.getDisplaySetsForSeries(seriesUID);


### PR DESCRIPTION
## Summary
- Add optional `clearCache` boolean (default `true`) to the `loadSeries` postMessage interface
- When true, calls `cornerstone.cache.purgeCache()` before switching series

## Context
The review service's iframe pool ([review-service PR #86](https://github.com/gradienthealth/review-service/pull/86)) recycles viewer slots via postMessage when prefetch targets change. Without clearing the cache, each slot accumulates decoded pixel data from every series it has displayed, causing unbounded memory growth (observed 5.4GB+ in testing).

Defaulting `clearCache: true` means callers get bounded memory automatically. Pass `clearCache: false` to retain cached data across series switches if desired.

## Test plan
- [ ] Send `loadSeries` without `clearCache` field — verify cache is purged (default true)
- [ ] Send `loadSeries` with `clearCache: false` — verify cache is retained
- [ ] Monitor memory in Chrome Task Manager during repeated series switches — should stay bounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)