### PR TITLE
DQ-313 - Post seriesReady message to parent when first image renders

### DIFF
--- a/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
+++ b/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
@@ -1,4 +1,11 @@
 import { useEffect } from 'react';
+import { EVENTS, getEnabledElement } from '@cornerstonejs/core';
+
+/** Message posted to the parent frame when the viewer has rendered a series' first image. */
+interface SeriesReadyMessage {
+  type: 'seriesReady';
+  seriesUID: string;
+}
 
 /** Message sent by a parent frame to switch the displayed series without a full SPA reload. */
 interface LoadSeriesMessage {
@@ -145,4 +152,43 @@ export function usePostMessageSeriesSwitching({
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
   }, [enabled, servicesManager, displaySetService, dataSource]);
+
+  // Post seriesReady to parent when the viewer renders its first image for any series.
+  // Fires on both initial iframe.src loads and postMessage-based series switches.
+  useEffect(() => {
+    if (!enabled || !window.parent || window.parent === window) return;
+
+    const { viewportGridService } = servicesManager.services;
+    const notifiedSeries = new Set<string>();
+
+    function handleImageRendered(evt: Event) {
+      const detail = (evt as CustomEvent).detail;
+      if (detail?.viewportStatus === 'preRender') return;
+
+      const element = detail?.element;
+      if (!element) return;
+
+      const enabledElement = getEnabledElement(element);
+      if (!enabledElement) return;
+
+      // Resolve series UID through the canonical OHIF path:
+      // viewport element → viewportId → displaySetInstanceUIDs → display set → SeriesInstanceUID
+      const viewportState = viewportGridService.getState().viewports.get(enabledElement.viewportId);
+      const displaySetUID = viewportState?.displaySetInstanceUIDs?.[0];
+      if (!displaySetUID) return;
+
+      const displaySet = displaySetService.getDisplaySetByUID(displaySetUID);
+      const seriesUID = displaySet?.SeriesInstanceUID;
+      if (!seriesUID || notifiedSeries.has(seriesUID)) return;
+
+      notifiedSeries.add(seriesUID);
+      const message: SeriesReadyMessage = { type: 'seriesReady', seriesUID };
+      window.parent.postMessage(message, '*');
+    }
+
+    // IMAGE_RENDERED fires on viewport DOM elements; capture at document level
+    // to avoid tracking individual element lifecycles.
+    document.addEventListener(EVENTS.IMAGE_RENDERED, handleImageRendered, true);
+    return () => document.removeEventListener(EVENTS.IMAGE_RENDERED, handleImageRendered, true);
+  }, [enabled, servicesManager, displaySetService]);
 }


### PR DESCRIPTION
## Summary
- Post `{ type: 'seriesReady', seriesUID }` to the parent frame when Cornerstone renders the first image for a series
- Series UID resolved through canonical OHIF path: viewport element → viewportId → displaySetInstanceUIDs → display set → SeriesInstanceUID
- Fires once per unique series render (both initial `iframe.src` loads and postMessage-based switches)
- Listens via document-level capture on Cornerstone's `IMAGE_RENDERED` event

## Context
The review service's iframe pool needs to know when a prefetched series is actually ready to display (has pixels on screen), not just when the HTML document loaded. This message replaces the inaccurate `iframe.onload` signal with a precise "first frame rendered" notification.

Used by [review-service PR #88](https://github.com/gradienthealth/review-service/pull/88) to show prefetch status indicators (blue dot = loading, green dot = rendered) in the series list.

## Test plan
- [ ] Load OHIF in an iframe — verify `seriesReady` message posted to parent after first image renders
- [ ] Verify message contains correct `seriesUID`
- [ ] Verify message fires only once per series (not on every re-render frame)
- [ ] Verify no message for `preRender` viewport status

🤖 Generated with [Claude Code](https://claude.com/claude-code)