### PR TITLE
DQ-313 - Remove preRender filter from seriesReady handler

### DIFF
--- a/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
+++ b/platform/app/src/routes/Mode/usePostMessageSeriesSwitching.ts
@@ -167,8 +167,6 @@ export function usePostMessageSeriesSwitching({
     const notifiedSeries = new Set<string>();
 
     function handleImageRendered(evt: Event) {
-      const detail = (evt as CustomEvent).detail;
-      if (detail?.viewportStatus === 'preRender') return;
       if (!currentSeriesUID || notifiedSeries.has(currentSeriesUID)) return;
 
       notifiedSeries.add(currentSeriesUID);


### PR DESCRIPTION
## Summary
Remove the `viewportStatus === 'preRender'` filter from the `seriesReady` postMessage handler.

## Problem
`IMAGE_RENDERED` in the current Cornerstone build only fires with `viewportStatus: 'preRender'` — the expected non-preRender event never occurs. This caused `seriesReady` to never post to the parent frame, leaving prefetch status dots permanently blue.

## Fix
Remove the filter. The `preRender` event still indicates DICOM data has been fetched, decoded, and assigned to the viewport, which is a valid "ready to display" signal. The `notifiedSeries` set already ensures we fire only once per series.

## How to test before merging
1. Deploy atlas from this branch (or build locally with `APP_CONFIG=config/gradient.js yarn run dev`)
2. Open the review-service dev deployment
3. Sign in and navigate to a review page
4. Verify prefetch dots turn from blue to green as series load

🤖 Generated with [Claude Code](https://claude.com/claude-code)