### PR TITLE
DQ-322 - Add leftPanelEnabled/rightPanelEnabled URL params to disable side panels

### DIFF
--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -153,14 +153,23 @@ export default function ModeRoute({
       if (isMounted.current) {
         const { leftPanels = [], rightPanels = [], ...layoutProps } = layoutData.props;
 
+        // Allow URL params to disable panels entirely (prevents pop-in when
+        // embedding the viewer in an iframe with panels not needed)
+        const leftPanelEnabled = lowerCaseSearchParams.get('leftpanelenabled') !== 'false';
+        const rightPanelEnabled = lowerCaseSearchParams.get('rightpanelenabled') !== 'false';
+
         panelService.reset();
-        panelService.addPanels(panelService.PanelPosition.Left, leftPanels);
-        panelService.addPanels(panelService.PanelPosition.Right, rightPanels);
+        if (leftPanelEnabled) {
+          panelService.addPanels(panelService.PanelPosition.Left, leftPanels);
+        }
+        if (rightPanelEnabled) {
+          panelService.addPanels(panelService.PanelPosition.Right, rightPanels);
+        }
 
         // layoutProps contains all props but leftPanels and rightPanels
         layoutData.props = layoutProps;
 
-        // Allow URL params to override panel closed state
+        // Allow URL params to override panel closed state (only relevant if panels are enabled)
         const urlLeftPanelClosed = lowerCaseSearchParams.get('leftpanelclosed');
         const urlRightPanelClosed = lowerCaseSearchParams.get('rightpanelclosed');
         if (urlLeftPanelClosed !== null) {


### PR DESCRIPTION
## Summary
- Add `leftPanelEnabled` and `rightPanelEnabled` URL query params (default `true`)
- When set to `false`, panels are not added to the panel service at all, preventing them from appearing in the DOM

## Problem
The existing `leftPanelClosed=true` / `rightPanelClosed=true` params close panels after they're created, causing a visible pop-in: panels briefly appear at full width, then close, shrinking the viewport. This is jarring when embedding the viewer in an iframe.

## Fix
The new `Enabled` params prevent panels from being registered with the panel service entirely. No DOM elements, no pop-in. The existing `Closed` params are preserved for cases where panels should exist but start collapsed.

## Test plan
- [ ] Load viewer with `?leftPanelEnabled=false&rightPanelEnabled=false` - no side panels should appear at any point
- [ ] Load viewer with no params - panels appear as normal (default true)
- [ ] Load viewer with `?leftPanelClosed=true` - left panel exists but starts closed (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)