### PR TITLE
DQ-344 - Fix viewer rendering for series with bad VOI or rescale metadata

### DIFF
--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -858,6 +858,15 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
 
     return viewport.setStack(imageIds, initialImageIndexToUse).then(() => {
       viewport.setProperties({ ...properties });
+
+      // Auto-windowing: after the viewport is set up, check if the current VOI
+      // range actually overlaps with the real pixel data. If not (e.g. due to
+      // bogus RescaleIntercept from de-identification, or missing WW/WC metadata),
+      // recompute VOI from pixel data percentiles to prevent all-white/all-black images.
+      if (!properties.voiRange) {
+        this._fixStackVoiIfNeeded(viewport);
+      }
+
       this.setPresentations(viewport.id, presentations, viewportInfo);
 
       if (overlayProcessingResults?.length) {
@@ -878,6 +887,102 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
         viewport.setCamera({ flipHorizontal: true });
       }
     });
+  }
+
+  /**
+   * Checks whether a stack viewport's current VOI range overlaps with the
+   * actual pixel data range. If not (e.g. due to bogus RescaleIntercept from
+   * de-identification, or missing WW/WC), recomputes VOI from pixel data
+   * percentiles to prevent all-white or all-black rendering.
+   *
+   * Only applies to stack viewports — volume viewports handle bad metadata
+   * correctly via cornerstone's internal VOI computation.
+   */
+  private _fixStackVoiIfNeeded(viewport: Types.IStackViewport) {
+    try {
+      // 1. Get the pixel data from the loaded image. scalarData already has
+      //    the modality LUT (rescale slope/intercept) applied by cornerstone.
+      const imageData = viewport.getImageData();
+      if (!imageData?.scalarData) {
+        return;
+      }
+      const scalarData = imageData.scalarData as
+        | Float32Array
+        | Int16Array
+        | Uint16Array
+        | Uint8Array
+        | Int8Array;
+
+      if (scalarData.length === 0) {
+        return;
+      }
+
+      // 2. Compute the 0.5th/99.5th percentiles of the pixel data to get a
+      //    robust data range that excludes outliers.
+      const percentiles = this._computePercentiles(scalarData);
+      if (!percentiles) {
+        return;
+      }
+      const { pLow, pHigh } = percentiles;
+
+      // 3. Check if the viewport's current VOI range overlaps with the actual
+      //    pixel data. If it does, the image is rendering correctly — bail out.
+      const voiRange = viewport.getProperties()?.voiRange;
+      if (voiRange && pLow < voiRange.upper && pHigh > voiRange.lower) {
+        return;
+      }
+
+      // 4. No overlap (or no VOI set) — override with percentile-based window.
+      const windowWidth = Math.max(1, pHigh - pLow);
+      const windowCenter = (pHigh + pLow) / 2;
+      const { lower, upper } = csUtils.windowLevel.toLowHighRange(windowWidth, windowCenter);
+      viewport.setProperties({ voiRange: { lower, upper } });
+
+      // 5. Warn the user so they know the metadata is suspect.
+      const { uiNotificationService } = this.servicesManager.services;
+      uiNotificationService?.show({
+        title: 'Auto-Windowing Applied',
+        message:
+          'This image has invalid VOI or rescale metadata. Window/level was computed from pixel data.',
+        type: 'warning',
+        duration: Infinity,
+      });
+    } catch (e) {
+      console.warn('Auto VOI fix failed:', e);
+    }
+  }
+
+  /**
+   * Computes the 0.5th and 99.5th percentiles from a typed pixel data array.
+   * Samples up to 100k pixels for performance on large datasets.
+   */
+  private _computePercentiles(
+    scalarData: Float32Array | Int16Array | Uint16Array | Uint8Array | Int8Array
+  ): { pLow: number; pHigh: number } | null {
+    const length = scalarData.length;
+    if (length === 0) {
+      return null;
+    }
+
+    const maxSamples = 100_000;
+    let samples: number[];
+
+    if (length <= maxSamples) {
+      samples = Array.from(scalarData);
+    } else {
+      samples = new Array(maxSamples);
+      const step = length / maxSamples;
+      for (let i = 0; i < maxSamples; i++) {
+        samples[i] = scalarData[Math.floor(i * step)];
+      }
+    }
+
+    samples.sort((a, b) => a - b);
+
+    return {
+      pLow: samples[Math.floor(samples.length * 0.005)],
+      pHigh: samples[Math.floor(samples.length * 0.995)],
+    };
   }
 
   private _getInitialImageIndexForViewport(


### PR DESCRIPTION
Some de-identified DICOM series have a bogus `RescaleIntercept` (e.g. 31744 instead of -1024) that shifts pixel values far outside the `WindowCenter`/`WindowWidth` range, rendering the image all-white. Reviewers currently work around this by running an external Python script to normalize pixel data before viewing in RadiAnt. This fix makes the viewer handle it automatically.

## Example 
[series with no 3D views](https://gradienthealth.github.io/atlas/viewer/cod?StudyInstanceUIDs=1.2.826.0.1.3680043.8.498.20949518474897385293444407767894338867&SeriesInstanceUIDs=1.2.826.0.1.3680043.8.498.10347838856675295951930618884570723950&bucket=thryothor-495511-pacs-deid&bucket-prefix=v1.0/dicomweb)

[series with 3D views](https://gradienthealth.github.io/atlas/viewer/cod?StudyInstanceUIDs=1.2.826.0.1.3680043.8.498.20741711644969544194990188373071960880&SeriesInstanceUIDs=1.2.826.0.1.3680043.8.498.66105338337151112057194521604603724565&bucket=clanga-65737-pacs-deid&bucket-prefix=v1.0/dicomweb)

### How Series Appears in Prod
<img width="1470" height="923" alt="Screenshot 2026-04-10 at 10 50 09 AM" src="https://github.com/user-attachments/assets/43ffa96f-7622-41b7-94b7-3c7a39c0e9d3" />

### How Series Appears after changes (served locally)
<img width="1470" height="923" alt="Screenshot 2026-04-10 at 10 51 08 AM" src="https://github.com/user-attachments/assets/ce3c15b9-de34-42a1-9c36-96ce0e533361" />

## Changes

- Add `_fixStackVoiIfNeeded` to `CornerstoneViewportService` that runs after stack viewport initialization when no explicit VOI is provided via URL params or config
- Sample up to 100k pixels from the viewport's scalar data (which already has modality LUT applied) and compute 0.5th/99.5th percentiles
- Compare the percentile range against the viewport's current VOI range — if they don't overlap, override with the percentile-based window
- Show a persistent warning notification when auto-windowing is applied so reviewers know the metadata is suspect
- Stack viewports only — volume viewports handle bad metadata correctly via cornerstone's internal VOI computation, so no fix needed there

Only triggers when: (1) no VOI was set from config/URL, and (2) the existing VOI range doesn't overlap the actual pixel data. Normal series with correct metadata are unaffected.

### Regression testing

Tested locally across 12 modalities (CT, CR, DR, DX, MG, MR, NM, OT, PT, RF, US, XA) using reviewed-clean series from diverse institutions. All rendered correctly in all viewport modes (stack, MPR, 3D four-up) with no regressions. Both broken series (thryothor-495511 and clanga-65737, both with bad RescaleIntercept) now render correctly in stack viewports with the warning notification displayed, and volume viewports remain functional.