### PR TITLE
DQ-350 - Fix deploy workflows to only trigger on merge, add manual dispatch

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     types: [closed]
     branches: [nightly]
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     strategy:
@@ -43,6 +45,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: gradienthealth/Viewers
+          ref: nightly
           path: ./Viewers
 
       - name: Link

--- a/.github/workflows/deploy_production_ghpages.yml
+++ b/.github/workflows/deploy_production_ghpages.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     types: [closed]
     branches: ['production']
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     strategy:
@@ -43,6 +45,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: gradienthealth/Viewers
+          ref: production
           path: ./Viewers
 
       - name: Link


### PR DESCRIPTION
Deploy workflows fired on any PR close against production/nightly — including close without merge. This caused unmerged code from PR #95 to be accidentally deployed to production when the PR was closed to re-trigger a check.

- Add `if: github.event.pull_request.merged == true` guard on both deploy workflows so they only run on actual merges
- Add `workflow_dispatch` trigger to both workflows for manual deploys from the Actions tab
- Pin Viewers checkout to the target branch (`ref: production` / `ref: nightly`) instead of defaulting to the PR merge ref

**Merging this PR will also trigger a clean production redeploy**, reverting the accidental deploy from #95.