### PR TITLE
PROC-1327 - Fix black screen for 4D dynamic volumes with bad rescale metadata

### DIFF
--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -12,6 +12,7 @@ import {
   cache,
   Enums as csEnums,
   BaseVolumeViewport,
+  eventTarget,
 } from '@cornerstonejs/core';
 
 import { utilities as csToolsUtils, Enums as csToolsEnums } from '@cornerstonejs/tools';
@@ -953,6 +954,110 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
   }
 
   /**
+   * Volume-viewport counterpart to _fixStackVoiIfNeeded, scoped to dynamic
+   * (4D) volumes at the call site. Defers sampling until the volume finishes
+   * streaming, then overrides voiRange only if the current window has zero
+   * overlap with actual pixel data.
+   *
+   * Why this is only needed for dynamic volumes:
+   * - Cornerstone's setDefaultVolumeVOI tries metadata WW/WC first; if that
+   *   returns nothing it falls back to sampling the middle slice's pixel min/max.
+   * - For regular streaming volumes with bad metadata but missing WW/WC, the
+   *   pixel-min/max fallback self-heals — this is the series that shipped with
+   *   DQ-344's stack fix.
+   * - For dynamic volumes with WW/WC present but bogus (e.g. de-id'd with
+   *   RescaleIntercept=32768 and missing RescaleSlope), cornerstone uses the
+   *   (bad) metadata and never hits the fallback, and the GPU ends up with
+   *   signed-space pixels while voiRange sits in a mismatched unsigned space.
+   *   Result: fully black render.
+   */
+  private _fixDynamicVolumeVoiIfNeeded(viewport: Types.IVolumeViewport, volumeId: string) {
+    const volume = cache.getVolume(volumeId);
+    if (!volume?.imageIds?.length) {
+      return;
+    }
+
+    const loadedHandler = (evt: { detail?: { volumeId?: string } }) => {
+      if (evt?.detail?.volumeId !== volumeId) {
+        return;
+      }
+      eventTarget.removeEventListener(
+        csEnums.Events.IMAGE_VOLUME_LOADING_COMPLETED,
+        loadedHandler
+      );
+
+      try {
+        const [min, max] = this._sampleVolumePixelRange(volumeId);
+        if (!Number.isFinite(min) || !Number.isFinite(max) || min === max) {
+          return;
+        }
+
+        const voiRange = viewport.getProperties(volumeId)?.voiRange;
+        if (voiRange && min < voiRange.upper && max > voiRange.lower) {
+          return;
+        }
+
+        const windowWidth = Math.max(1, max - min);
+        const windowCenter = (max + min) / 2;
+        const { lower, upper } = csUtils.windowLevel.toLowHighRange(windowWidth, windowCenter);
+        viewport.setProperties({ voiRange: { lower, upper } }, volumeId);
+        viewport.render();
+
+        const { uiNotificationService } = this.servicesManager.services;
+        uiNotificationService?.show({
+          title: 'Auto-Windowing Applied',
+          message:
+            'This image has invalid VOI or rescale metadata. Window/level was computed from pixel data.',
+          type: 'warning',
+          duration: Infinity,
+        });
+      } catch (e) {
+        console.warn('Auto volume VOI fix failed:', e);
+      }
+    };
+
+    eventTarget.addEventListener(
+      csEnums.Events.IMAGE_VOLUME_LOADING_COMPLETED,
+      loadedHandler
+    );
+  }
+
+  /**
+   * Samples raw typed-array pixel values from ~8 cached images across the
+   * volume. Returns [min, max] in the same numeric space as the GPU texture
+   * — critical for voiRange-matching, since image.minPixelValue/maxPixelValue
+   * can report the unsigned interpretation while the actual typed array is
+   * Int16 (or vice versa).
+   */
+  private _sampleVolumePixelRange(volumeId: string): [number, number] {
+    const volume = cache.getVolume(volumeId);
+    const imageIds = volume?.imageIds || [];
+    const sampleCount = Math.min(imageIds.length, 8);
+    const stride = Math.max(1, Math.floor(imageIds.length / sampleCount));
+
+    let min = Infinity;
+    let max = -Infinity;
+    for (let i = 0; i < imageIds.length; i += stride) {
+      const img = cache.getImage?.(imageIds[i]);
+      const s = img?.voxelManager?.getScalarData?.();
+      if (!s?.length) {
+        continue;
+      }
+      const pixelStride = Math.max(1, Math.floor(s.length / 10_000));
+      for (let j = 0; j < s.length; j += pixelStride) {
+        const v = s[j];
+        if (v < min) {
+          min = v;
+        }
+        if (v > max) {
+          max = v;
+        }
+      }
+    }
+    return [min, max];
+  }
+
+  /**
    * Computes the 0.5th and 99.5th percentiles from a typed pixel data array.
    * Samples up to 100k pixels for performance on large datasets.
    */
@@ -1225,6 +1330,17 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
       timeoutViewportCallback(() => {
         viewport.setProperties(properties, volumeId);
         viewport.render();
+
+        // Auto-windowing for dynamic (4D) volumes with invalid VOI/rescale
+        // metadata. Regular volumes self-heal via cornerstone's own fallback;
+        // dynamic volumes don't, and hit this path instead. See
+        // _fixDynamicVolumeVoiIfNeeded for the full rationale.
+        if (viewport instanceof BaseVolumeViewport) {
+          const volume = cache.getVolume(volumeId);
+          if (volume?.isDynamicVolume?.()) {
+            this._fixDynamicVolumeVoiIfNeeded(viewport as Types.IVolumeViewport, volumeId);
+          }
+        }
       });
     });
 


### PR DESCRIPTION
## What was broken

Diffusion-weighted MR series (and other 4D/dynamic studies) with de-identified or otherwise-malformed rescale metadata rendered as a completely black viewport. Scrolling/cine behaved normally, pixel data streamed in fine, but the window/level fell entirely outside the rendered pixel range → all pixels clipped to black.

- **Who hit it:** dynamic (4D) volumes that cornerstone splits by a `splittingTag` (e.g. DWI series split by DiffusionBValue, producing N×32 instances with a 1/N dimension-group selector in the cine bar).
- **Modalities/modes observed:** MR DWI/ADC series (4D streaming dynamic volume). By extension, any dynamic volume where DICOM metadata says `WindowCenter`/`WindowWidth` exist but `RescaleSlope` is missing or otherwise bogus.
- **Viewport types affected:** volume viewports specifically (stack rendering was already covered by DQ-344).

## Root cause

Cornerstone's `setDefaultVolumeVOI` prefers metadata `WW`/`WC` when both are present on the series' middle image. For de-identified series the metadata often has `RescaleIntercept=32768` plus a missing `RescaleSlope`, and the de-id tool has already shifted the signed pixel data into unsigned-looking integers. The net effect:

- GPU texture ends up with pixel values in the actual rescaled/shifted space (e.g. `Int16Array` whose values happen to read `[-32768, -25327]` or `Uint16Array` `[32768, 42437]`, depending on how the loader typed the buffer).
- `voiRange` ends up in the unrelated metadata space (e.g. `[0, 644]`).
- No overlap between window and data → fully black.

DQ-344's existing stack-viewport auto-windowing didn't cover this path because dynamic volumes go through `setVolumesForViewport`, not the stack path. Cornerstone's own middle-slice pixel-sampling fallback inside `setDefaultVolumeVOI` is _skipped_ when any WC/WW is present, so the volume path doesn't self-heal for this class of bad metadata.

## The fix

Targeted auto-windowing for **dynamic volume viewports only**, in `CornerstoneViewportService.setVolumesForViewport`:

1. When a viewport's underlying volume is a dynamic volume (`volume.isDynamicVolume()` is true), attach a one-shot listener for `Events.IMAGE_VOLUME_LOADING_COMPLETED`.
2. When the event fires, sample raw typed-array pixel values from ~8 cached images across the volume, skipping 1 sample per ~10k pixels per image. This gives us `[min, max]` in **exactly the same numeric space as the GPU texture** — including signedness — which is critical because `image.minPixelValue`/`maxPixelValue` can disagree with the underlying `Int16Array`/`Uint16Array`'s actual values for these series.
3. If the viewport's current `voiRange` overlaps the sampled `[min, max]` at all, leave it alone.
4. Otherwise, override `voiRange` to the full sampled span (no percentile-based outlier rejection — simpler, and adequate for making the image visible) and show the same "Auto-Windowing Applied" notification DQ-344 added.

Scope choices and why:
- **Dynamic-only gate.** Regular volumes self-heal via cornerstone's pixel-sampling fallback. An earlier version of this fix applied to all volume viewports and broke 3D four-up rendering on a series that previously rendered fine — a post-load `setProperties({ voiRange })` on a non-dynamic volume's 3D viewport races cornerstone's opacity/transfer-function setup. Dynamic volumes don't have that post-setup behavior to conflict with.
- **Defer to `IMAGE_VOLUME_LOADING_COMPLETED`.** Sampling immediately after `setVolumes` resolves returns no data (streaming is still in flight), causing the override to skip. Waiting for full load completion guarantees enough pixel data is cached.
- **Sample raw typed arrays instead of `voxelManager.getRange()`.** We saw cases where `getRange()` returned `[32768, 42437]` (from `image.minPixelValue`/`maxPixelValue`) while the underlying array was `Int16Array` with values `[-32768, -25327]`. Setting `voiRange` in the former space produces black when the GPU reads the latter.
- **Only override on zero overlap.** Keeps us out of the way when cornerstone's VOI is already sane.

## Test plan

The production links below reproduce the bug and the regression-guard behavior against the hosted atlas. To verify against this branch locally, serve it with any config that exposes the two data sources used below (`thryothor-495511-pacs-deid/v1.0` and `clanga-65737-pacs-deid/v1.0`) and swap the `https://.../atlas/viewer/` prefix for your local equivalent. If your buckets require auth, OHIF accepts a bearer token via `?token=<access_token>` on the viewer URL (see `platform/app/src/routes/Mode/Mode.tsx`).

**proc-1327 — the broken series**

All black in current prod:
```
https://gradienthealth.github.io/atlas/viewer/thryothor-495511-pacs-deid/v1.0?StudyInstanceUIDs=1.2.826.0.1.3680043.8.498.86114562220811432313310407692399345798&SeriesInstanceUIDs=1.2.826.0.1.3680043.8.498.90424059860696909766753998803465688785&leftPanelEnabled=false&rightPanelEnabled=false
```

If you try this locally from this branch instead (e.g. `yarn run dev; localhost:3000`), renders properly:

<img width="1470" height="923" alt="Screenshot 2026-04-21 at 3 27 01 PM" src="https://github.com/user-attachments/assets/5705d949-d784-4046-950f-78c38a809c02" />


**PROC-1353 / DQ-327 — regression guard**

Works in prod:
```
https://gradienthealth.github.io/atlas/viewer/clanga-65737-pacs-deid/v1.0?StudyInstanceUIDs=1.2.826.0.1.3680043.8.498.20741711644969544194990188373071960880&SeriesInstanceUIDs=1.2.826.0.1.3680043.8.498.66105338337151112057194521604603724565&leftPanelEnabled=false&rightPanelEnabled=false
```

Still works locally

### Checklist

- [ ] proc-1327: default stack view renders; "Auto-Windowing Applied" notification appears.
- [ ] proc-1327: switch to 3D four-up — all 4 panels render.
- [ ] PROC-1353 / DQ-327: default stack view renders with auto-windowing notification (existing DQ-344 behavior, unchanged).
- [ ] PROC-1353 / DQ-327: switch to 3D four-up — renders correctly, **no** new notification fires, no black screen.
- [ ] Pick any previously-working series in the atlas with normal metadata — confirm no regression, no spurious notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)