### PR TITLE
PROC-1577 - Submit PHIBoundingBox annotations as redaction payload

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -2509,7 +2509,7 @@ function commandsModule({
       });
     },
 
-    submitRedactionPayload: async () => {
+    submitRedactionPayload: () => {
       const NOTIFY_TITLE = 'Submit PHI Redaction';
       const activeDisplaySet = displaySetService.getActiveDisplaySets()?.[0];
       if (!activeDisplaySet) {
@@ -2539,17 +2539,11 @@ function commandsModule({
         return;
       }
 
-      const userAuth = (servicesManager.services as AppTypes.Services).userAuthenticationService;
-      const user = userAuth?.getUser?.();
-      const reviewer: string | undefined =
-        user?.profile?.email ?? user?.email ?? user?.profile?.preferred_username ?? undefined;
-
       let payload;
       try {
         payload = buildRedactionPayload({
           studyUid,
           seriesUid,
-          reviewer,
           annotations: measurements.map(m => ({
             points: m.points,
             referencedImageId: m.referencedImageId,
@@ -2571,44 +2565,25 @@ function commandsModule({
         return;
       }
 
-      const url: string | undefined = (window as Window & { config?: any }).config?.redactionApi
-        ?.url;
-      if (!url) {
+      if (!window.parent || window.parent === window) {
         uiNotificationService.show({
           title: NOTIFY_TITLE,
-          message: 'redactionApi.url is not set in the app config.',
+          message: 'Viewer is not embedded — no parent frame to submit to.',
           type: 'error',
           duration: 8000,
         });
         return;
       }
 
-      try {
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        });
-        if (!res.ok) {
-          const body = await res.text();
-          throw new Error(`HTTP ${res.status}: ${body || res.statusText}`);
-        }
-        const count = payload.redactions.length;
-        uiNotificationService.show({
-          title: NOTIFY_TITLE,
-          message: `Submitted ${count} redaction${count === 1 ? '' : 's'} for series.`,
-          type: 'success',
-          duration: 5000,
-        });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'POST failed.';
-        uiNotificationService.show({
-          title: NOTIFY_TITLE,
-          message,
-          type: 'error',
-          duration: 8000,
-        });
-      }
+      window.parent.postMessage({ type: 'phiRedactionSubmit', payload }, '*');
+
+      const count = payload.redactions.length;
+      uiNotificationService.show({
+        title: NOTIFY_TITLE,
+        message: `Submitted ${count} redaction${count === 1 ? '' : 's'} for review.`,
+        type: 'success',
+        duration: 5000,
+      });
     },
   };
 

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -49,6 +49,10 @@ import { toolNames } from './initCornerstoneTools';
 import CornerstoneViewportDownloadForm from './utils/CornerstoneViewportDownloadForm';
 import { updateSegmentBidirectionalStats } from './utils/updateSegmentationStats';
 import { generateSegmentationCSVReport } from './utils/generateSegmentationCSVReport';
+import {
+  buildRedactionPayload,
+  RedactionOutOfBoundsError,
+} from './utils/buildRedactionPayload';
 import { getUpdatedViewportsForSegmentation } from './utils/hydrationUtils';
 import { SegmentationRepresentations } from '@cornerstonejs/tools/enums';
 import { isMeasurementWithinViewport } from './utils/isMeasurementWithinViewport';
@@ -2504,6 +2508,108 @@ function commandsModule({
         containerClassName: 'max-w-[90vw] w-max',
       });
     },
+
+    submitRedactionPayload: async () => {
+      const NOTIFY_TITLE = 'Submit PHI Redaction';
+      const activeDisplaySet = displaySetService.getActiveDisplaySets()?.[0];
+      if (!activeDisplaySet) {
+        uiNotificationService.show({
+          title: NOTIFY_TITLE,
+          message: 'No active display set.',
+          type: 'error',
+        });
+        return;
+      }
+      const studyUid = activeDisplaySet.StudyInstanceUID;
+      const seriesUid = activeDisplaySet.SeriesInstanceUID;
+
+      const measurements = measurementService.getMeasurements(
+        m =>
+          m.toolName === 'PHIBoundingBox' &&
+          m.referenceStudyUID === studyUid &&
+          m.referenceSeriesUID === seriesUid
+      );
+
+      if (measurements.length === 0) {
+        uiNotificationService.show({
+          title: NOTIFY_TITLE,
+          message: 'No PHI bounding boxes drawn for the active series.',
+          type: 'warning',
+        });
+        return;
+      }
+
+      const userAuth = (servicesManager.services as AppTypes.Services).userAuthenticationService;
+      const user = userAuth?.getUser?.();
+      const reviewer: string | undefined =
+        user?.profile?.email ?? user?.email ?? user?.profile?.preferred_username ?? undefined;
+
+      let payload;
+      try {
+        payload = buildRedactionPayload({
+          studyUid,
+          seriesUid,
+          reviewer,
+          annotations: measurements.map(m => ({
+            points: m.points,
+            referencedImageId: m.referencedImageId,
+            SOPInstanceUID: m.SOPInstanceUID,
+            frameNumber: m.frameNumber ?? 1,
+          })),
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to build redaction payload.';
+        uiNotificationService.show({
+          title: NOTIFY_TITLE,
+          message:
+            err instanceof RedactionOutOfBoundsError
+              ? `${message} Adjust the offending box and try again.`
+              : message,
+          type: 'error',
+          duration: 8000,
+        });
+        return;
+      }
+
+      const url: string | undefined = (window as Window & { config?: any }).config?.redactionApi
+        ?.url;
+      if (!url) {
+        uiNotificationService.show({
+          title: NOTIFY_TITLE,
+          message: 'redactionApi.url is not set in the app config.',
+          type: 'error',
+          duration: 8000,
+        });
+        return;
+      }
+
+      try {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(`HTTP ${res.status}: ${body || res.statusText}`);
+        }
+        const count = payload.redactions.length;
+        uiNotificationService.show({
+          title: NOTIFY_TITLE,
+          message: `Submitted ${count} redaction${count === 1 ? '' : 's'} for series.`,
+          type: 'success',
+          duration: 5000,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'POST failed.';
+        uiNotificationService.show({
+          title: NOTIFY_TITLE,
+          message,
+          type: 'error',
+          duration: 8000,
+        });
+      }
+    },
   };
 
   const definitions = {
@@ -2831,6 +2937,7 @@ function commandsModule({
       commandFn: actions.reCalibrateWindowLevel,
     },
     showOPFSManagementTool: actions.showOPFSManagementTool,
+    submitRedactionPayload: actions.submitRedactionPayload,
   };
 
   return {

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -2511,46 +2511,71 @@ function commandsModule({
 
     submitRedactionPayload: () => {
       const NOTIFY_TITLE = 'Submit PHI Redaction';
-      const activeDisplaySet = displaySetService.getActiveDisplaySets()?.[0];
+
+      const activeViewportId = viewportGridService.getActiveViewportId();
+      const activeDisplaySet = (
+        activeViewportId
+          ? viewportGridService.getDisplaySetsUIDsForViewport(activeViewportId) ?? []
+          : []
+      )
+        .map(uid => displaySetService.getDisplaySetByUID(uid))
+        .find(ds => !!ds?.StudyInstanceUID);
+
       if (!activeDisplaySet) {
         uiNotificationService.show({
           title: NOTIFY_TITLE,
-          message: 'No active display set.',
+          message: 'No active viewport / study to submit redactions for.',
           type: 'error',
         });
         return;
       }
       const studyUid = activeDisplaySet.StudyInstanceUID;
-      const seriesUid = activeDisplaySet.SeriesInstanceUID;
 
-      const measurements = measurementService.getMeasurements(
-        m =>
-          m.toolName === 'PHIBoundingBox' &&
-          m.referenceStudyUID === studyUid &&
-          m.referenceSeriesUID === seriesUid
-      );
+      // Scope to the whole study, not a single series: in multi-viewport
+      // layouts the user may have drawn PHI on series they aren't currently
+      // focused on, and we don't want to silently drop those.
+      const allPhi = measurementService.getMeasurements(m => m.toolName === 'PHIBoundingBox');
+      const inStudy = allPhi.filter(m => m.referenceStudyUID === studyUid);
+      const skippedOtherStudies = allPhi.length - inStudy.length;
 
-      if (measurements.length === 0) {
+      if (inStudy.length === 0) {
         uiNotificationService.show({
           title: NOTIFY_TITLE,
-          message: 'No PHI bounding boxes drawn for the active series.',
+          message: 'No PHI bounding boxes drawn in the active study.',
           type: 'warning',
         });
         return;
       }
 
-      let payload;
+      const bySeries = new Map<string, typeof inStudy>();
+      for (const m of inStudy) {
+        const seriesUid = m.referenceSeriesUID;
+        let bucket = bySeries.get(seriesUid);
+        if (!bucket) {
+          bucket = [];
+          bySeries.set(seriesUid, bucket);
+        }
+        bucket.push(m);
+      }
+
+      // Build every series' payload first; if any series has an out-of-bounds
+      // box, abort the whole submit so we never post a partial set.
+      const payloads: ReturnType<typeof buildRedactionPayload>[] = [];
       try {
-        payload = buildRedactionPayload({
-          studyUid,
-          seriesUid,
-          annotations: measurements.map(m => ({
-            points: m.points,
-            referencedImageId: m.referencedImageId,
-            SOPInstanceUID: m.SOPInstanceUID,
-            frameNumber: m.frameNumber ?? 1,
-          })),
-        });
+        for (const [seriesUid, measurements] of bySeries) {
+          payloads.push(
+            buildRedactionPayload({
+              studyUid,
+              seriesUid,
+              annotations: measurements.map(m => ({
+                points: m.points,
+                referencedImageId: m.referencedImageId,
+                SOPInstanceUID: m.SOPInstanceUID,
+                frameNumber: m.frameNumber ?? 1,
+              })),
+            })
+          );
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to build redaction payload.';
         uiNotificationService.show({
@@ -2575,12 +2600,21 @@ function commandsModule({
         return;
       }
 
-      window.parent.postMessage({ type: 'phiRedactionSubmit', payload }, '*');
+      for (const payload of payloads) {
+        window.parent.postMessage({ type: 'phiRedactionSubmit', payload }, '*');
+      }
 
-      const count = payload.redactions.length;
+      const totalRedactions = payloads.reduce((sum, p) => sum + p.redactions.length, 0);
+      const seriesCount = payloads.length;
+      const skippedTail =
+        skippedOtherStudies > 0
+          ? ` (${skippedOtherStudies} PHI box${skippedOtherStudies === 1 ? '' : 'es'} on other studies were skipped.)`
+          : '';
       uiNotificationService.show({
         title: NOTIFY_TITLE,
-        message: `Submitted ${count} redaction${count === 1 ? '' : 's'} for review.`,
+        message:
+          `Submitted ${totalRedactions} redaction${totalRedactions === 1 ? '' : 's'} ` +
+          `across ${seriesCount} series.${skippedTail}`,
         type: 'success',
         duration: 5000,
       });

--- a/extensions/cornerstone/src/utils/buildRedactionPayload.test.ts
+++ b/extensions/cornerstone/src/utils/buildRedactionPayload.test.ts
@@ -1,0 +1,292 @@
+import {
+  buildRedactionPayload,
+  RedactionOutOfBoundsError,
+  PHIAnnotationInput,
+} from './buildRedactionPayload';
+
+jest.mock('@cornerstonejs/core', () => ({
+  utilities: { worldToImageCoords: jest.fn() },
+  metaData: { get: jest.fn() },
+}));
+
+import { utilities as csUtils, metaData } from '@cornerstonejs/core';
+
+const worldToImageCoords = csUtils.worldToImageCoords as jest.Mock;
+const metaDataGet = metaData.get as jest.Mock;
+
+const STUDY = 'study-1';
+const SERIES = 'series-1';
+
+function setImageDims({ rows, columns }: { rows: number; columns: number }) {
+  metaDataGet.mockImplementation((moduleId: string) => {
+    if (moduleId === 'imagePixelModule') return { rows, columns };
+    return {};
+  });
+}
+
+/**
+ * Per-corner mock: the i-th call to worldToImageCoords returns pixels[i].
+ * Annotations have 4 corners (RectangleROI), so for N annotations, supply 4*N entries.
+ */
+function setCornerPixels(pixels: number[][]) {
+  worldToImageCoords.mockReset();
+  pixels.forEach(p => worldToImageCoords.mockReturnValueOnce(p));
+}
+
+function annotation(overrides: Partial<PHIAnnotationInput> = {}): PHIAnnotationInput {
+  return {
+    points: [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ],
+    referencedImageId: 'image-1',
+    SOPInstanceUID: 'sop-1',
+    frameNumber: 1,
+    ...overrides,
+  };
+}
+
+describe('buildRedactionPayload', () => {
+  beforeEach(() => {
+    worldToImageCoords.mockReset();
+    metaDataGet.mockReset();
+    setImageDims({ rows: 512, columns: 512 });
+  });
+
+  it('emits one redaction with 0-based frame for a single in-bounds annotation', () => {
+    setCornerPixels([
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+    ]);
+
+    const payload = buildRedactionPayload({
+      studyUid: STUDY,
+      seriesUid: SERIES,
+      annotations: [annotation({ SOPInstanceUID: 'sop-A', frameNumber: 1 })],
+    });
+
+    expect(payload).toEqual({
+      study_uid: STUDY,
+      series_uid: SERIES,
+      redactions: [
+        {
+          box: { x: 10, y: 20, width: 30, height: 40 },
+          applies_to: ['sop-A'],
+          frames: [0],
+        },
+      ],
+    });
+  });
+
+  it('rounds float pixel coords to nearest integer before computing width/height', () => {
+    // (10.4, 20.6) and (40.5, 60.4) → rounded (10, 21) and (41, 60)
+    // width = 41 - 10 = 31; height = 60 - 21 = 39
+    setCornerPixels([
+      [10.4, 20.6],
+      [40.5, 20.6],
+      [40.5, 60.4],
+      [10.4, 60.4],
+    ]);
+
+    const payload = buildRedactionPayload({
+      studyUid: STUDY,
+      seriesUid: SERIES,
+      annotations: [annotation()],
+    });
+
+    expect(payload.redactions[0].box).toEqual({ x: 10, y: 21, width: 31, height: 39 });
+  });
+
+  it('rejects a box that rounds to zero width', () => {
+    // Both x corners round to 10 → width = 0
+    setCornerPixels([
+      [10.1, 20],
+      [10.4, 20],
+      [10.4, 60],
+      [10.1, 60],
+    ]);
+
+    expect(() =>
+      buildRedactionPayload({
+        studyUid: STUDY,
+        seriesUid: SERIES,
+        annotations: [annotation()],
+      })
+    ).toThrow(RedactionOutOfBoundsError);
+  });
+
+  it('rejects a box that exceeds image columns', () => {
+    setImageDims({ rows: 512, columns: 100 });
+    setCornerPixels([
+      [50, 20],
+      [120, 20], // 120 > columns (100)
+      [120, 60],
+      [50, 60],
+    ]);
+
+    expect(() =>
+      buildRedactionPayload({
+        studyUid: STUDY,
+        seriesUid: SERIES,
+        annotations: [annotation()],
+      })
+    ).toThrow(/100x512/);
+  });
+
+  it('rejects when rows/columns metadata is missing', () => {
+    metaDataGet.mockImplementation(() => ({}));
+    setCornerPixels([
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+    ]);
+
+    expect(() =>
+      buildRedactionPayload({
+        studyUid: STUDY,
+        seriesUid: SERIES,
+        annotations: [annotation()],
+      })
+    ).toThrow(/Missing rows\/columns/);
+  });
+
+  it('groups same-geometry annotations on one UID into a single redaction with sorted frames', () => {
+    // Two annotations on sop-A, same box, frames 5 and 1 (1-based).
+    setCornerPixels([
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+    ]);
+
+    const payload = buildRedactionPayload({
+      studyUid: STUDY,
+      seriesUid: SERIES,
+      annotations: [
+        annotation({ SOPInstanceUID: 'sop-A', frameNumber: 5 }),
+        annotation({ SOPInstanceUID: 'sop-A', frameNumber: 1 }),
+      ],
+    });
+
+    expect(payload.redactions).toEqual([
+      {
+        box: { x: 10, y: 20, width: 30, height: 40 },
+        applies_to: ['sop-A'],
+        frames: [0, 4],
+      },
+    ]);
+  });
+
+  it('groups same-geometry single-frame annotations across UIDs into one redaction', () => {
+    // Three slices, identical PHI burned into each at the same location.
+    setCornerPixels([
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+    ]);
+
+    const payload = buildRedactionPayload({
+      studyUid: STUDY,
+      seriesUid: SERIES,
+      annotations: [
+        annotation({ SOPInstanceUID: 'sop-C', frameNumber: 1 }),
+        annotation({ SOPInstanceUID: 'sop-A', frameNumber: 1 }),
+        annotation({ SOPInstanceUID: 'sop-B', frameNumber: 1 }),
+      ],
+    });
+
+    expect(payload.redactions).toHaveLength(1);
+    expect(payload.redactions[0]).toEqual({
+      box: { x: 10, y: 20, width: 30, height: 40 },
+      applies_to: ['sop-A', 'sop-B', 'sop-C'],
+      frames: [0],
+    });
+  });
+
+  it('splits same-geometry UIDs whose frame sets differ into separate redactions', () => {
+    // sop-A on frame 0; sop-B on frames 0 and 5. Same box.
+    setCornerPixels([
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+    ]);
+
+    const payload = buildRedactionPayload({
+      studyUid: STUDY,
+      seriesUid: SERIES,
+      annotations: [
+        annotation({ SOPInstanceUID: 'sop-A', frameNumber: 1 }),
+        annotation({ SOPInstanceUID: 'sop-B', frameNumber: 1 }),
+        annotation({ SOPInstanceUID: 'sop-B', frameNumber: 6 }),
+      ],
+    });
+
+    expect(payload.redactions).toHaveLength(2);
+    const byUid = new Map(payload.redactions.map(r => [r.applies_to.join(','), r]));
+    expect(byUid.get('sop-A')).toEqual({
+      box: { x: 10, y: 20, width: 30, height: 40 },
+      applies_to: ['sop-A'],
+      frames: [0],
+    });
+    expect(byUid.get('sop-B')).toEqual({
+      box: { x: 10, y: 20, width: 30, height: 40 },
+      applies_to: ['sop-B'],
+      frames: [0, 5],
+    });
+  });
+
+  it('keeps annotations with different geometry as separate redactions', () => {
+    setCornerPixels([
+      [10, 20],
+      [40, 20],
+      [40, 60],
+      [10, 60],
+      [100, 100],
+      [120, 100],
+      [120, 130],
+      [100, 130],
+    ]);
+
+    const payload = buildRedactionPayload({
+      studyUid: STUDY,
+      seriesUid: SERIES,
+      annotations: [
+        annotation({ SOPInstanceUID: 'sop-A', frameNumber: 1 }),
+        annotation({ SOPInstanceUID: 'sop-A', frameNumber: 1 }),
+      ],
+    });
+
+    expect(payload.redactions).toHaveLength(2);
+    expect(payload.redactions.map(r => r.box)).toEqual([
+      { x: 10, y: 20, width: 30, height: 40 },
+      { x: 100, y: 100, width: 20, height: 30 },
+    ]);
+  });
+});

--- a/extensions/cornerstone/src/utils/buildRedactionPayload.ts
+++ b/extensions/cornerstone/src/utils/buildRedactionPayload.ts
@@ -1,0 +1,174 @@
+import { utilities as csUtils, metaData } from '@cornerstonejs/core';
+
+export interface RedactionBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface Redaction {
+  box: RedactionBox;
+  applies_to: string[];
+  frames: number[] | null;
+}
+
+export interface RedactionPayload {
+  study_uid: string;
+  series_uid: string;
+  reviewer?: string;
+  redactions: Redaction[];
+}
+
+export interface PHIAnnotationInput {
+  points: number[][];
+  referencedImageId: string;
+  SOPInstanceUID: string;
+  frameNumber: number;
+}
+
+export class RedactionOutOfBoundsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RedactionOutOfBoundsError';
+  }
+}
+
+interface TransformedAnnotation extends RedactionBox {
+  sopUid: string;
+  frameIdx: number;
+}
+
+export function buildRedactionPayload({
+  studyUid,
+  seriesUid,
+  reviewer,
+  annotations,
+}: {
+  studyUid: string;
+  seriesUid: string;
+  reviewer?: string;
+  annotations: PHIAnnotationInput[];
+}): RedactionPayload {
+  const transformed = annotations.map(transformAnnotation);
+  const redactions = groupRedactions(transformed);
+
+  return {
+    study_uid: studyUid,
+    series_uid: seriesUid,
+    ...(reviewer ? { reviewer } : {}),
+    redactions,
+  };
+}
+
+function transformAnnotation(a: PHIAnnotationInput): TransformedAnnotation {
+  if (!a.points || a.points.length < 2) {
+    throw new RedactionOutOfBoundsError(
+      `PHI box for ${a.SOPInstanceUID} has fewer than 2 corner points`
+    );
+  }
+
+  const pixels = a.points.map(p => {
+    const ij = csUtils.worldToImageCoords(a.referencedImageId, p as [number, number, number]);
+    if (!ij) {
+      throw new RedactionOutOfBoundsError(
+        `Could not transform world coords to pixel coords for image ${a.referencedImageId}`
+      );
+    }
+    return ij;
+  });
+
+  const xs = pixels.map(p => p[0]);
+  const ys = pixels.map(p => p[1]);
+  const minX = Math.round(Math.min(...xs));
+  const minY = Math.round(Math.min(...ys));
+  const maxX = Math.round(Math.max(...xs));
+  const maxY = Math.round(Math.max(...ys));
+  const width = maxX - minX;
+  const height = maxY - minY;
+
+  const pixelModule = metaData.get('imagePixelModule', a.referencedImageId) ?? {};
+  const planeModule = metaData.get('imagePlaneModule', a.referencedImageId) ?? {};
+  const rows: number | undefined = pixelModule.rows ?? planeModule.rows;
+  const columns: number | undefined = pixelModule.columns ?? planeModule.columns;
+
+  if (rows == null || columns == null) {
+    throw new RedactionOutOfBoundsError(
+      `Missing rows/columns metadata for image ${a.referencedImageId}`
+    );
+  }
+
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    minX < 0 ||
+    minY < 0 ||
+    minX + width > columns ||
+    minY + height > rows
+  ) {
+    throw new RedactionOutOfBoundsError(
+      `PHI box for ${a.SOPInstanceUID} frame ${a.frameNumber} ` +
+        `is outside image bounds (${columns}x${rows}): ` +
+        `(x=${minX}, y=${minY}, w=${width}, h=${height})`
+    );
+  }
+
+  return {
+    x: minX,
+    y: minY,
+    width,
+    height,
+    sopUid: a.SOPInstanceUID,
+    frameIdx: a.frameNumber - 1,
+  };
+}
+
+function groupRedactions(items: TransformedAnnotation[]): Redaction[] {
+  const byGeom = new Map<string, TransformedAnnotation[]>();
+  for (const item of items) {
+    const key = `${item.x},${item.y},${item.width},${item.height}`;
+    let bucket = byGeom.get(key);
+    if (!bucket) {
+      bucket = [];
+      byGeom.set(key, bucket);
+    }
+    bucket.push(item);
+  }
+
+  const redactions: Redaction[] = [];
+  for (const bucket of byGeom.values()) {
+    const uidToFrames = new Map<string, Set<number>>();
+    for (const item of bucket) {
+      let frames = uidToFrames.get(item.sopUid);
+      if (!frames) {
+        frames = new Set<number>();
+        uidToFrames.set(item.sopUid, frames);
+      }
+      frames.add(item.frameIdx);
+    }
+
+    const byFrameSet = new Map<string, { frames: number[]; uids: string[] }>();
+    for (const [uid, frameSet] of uidToFrames) {
+      const sortedFrames = [...frameSet].sort((a, b) => a - b);
+      const key = sortedFrames.join(',');
+      let group = byFrameSet.get(key);
+      if (!group) {
+        group = { frames: sortedFrames, uids: [] };
+        byFrameSet.set(key, group);
+      }
+      group.uids.push(uid);
+    }
+
+    const { x, y, width, height } = bucket[0];
+    for (const { frames, uids } of byFrameSet.values()) {
+      uids.sort();
+      redactions.push({
+        box: { x, y, width, height },
+        applies_to: uids,
+        frames,
+      });
+    }
+  }
+
+  return redactions;
+}

--- a/modes/basic/src/index.tsx
+++ b/modes/basic/src/index.tsx
@@ -276,7 +276,7 @@ export const toolbarSections = {
     'OPFSTool',
   ],
 
-  PHIBoundingBox: ['PHIBoundingBox'],
+  PHIBoundingBox: ['PHIBoundingBox', 'SubmitRedaction'],
 };
 
 export const basicLayout = {

--- a/modes/basic/src/index.tsx
+++ b/modes/basic/src/index.tsx
@@ -274,6 +274,7 @@ export const toolbarSections = {
     'WindowLevelRegion',
     'SegmentLabelTool',
     'OPFSTool',
+    'PHIBoundingBox',
     'SubmitRedaction',
   ],
 

--- a/modes/basic/src/index.tsx
+++ b/modes/basic/src/index.tsx
@@ -274,9 +274,10 @@ export const toolbarSections = {
     'WindowLevelRegion',
     'SegmentLabelTool',
     'OPFSTool',
+    'SubmitRedaction',
   ],
 
-  PHIBoundingBox: ['PHIBoundingBox', 'SubmitRedaction'],
+  PHIBoundingBox: ['PHIBoundingBox'],
 };
 
 export const basicLayout = {

--- a/modes/basic/src/toolbarButtons.ts
+++ b/modes/basic/src/toolbarButtons.ts
@@ -530,6 +530,17 @@ const toolbarButtons: Button[] = [
     },
   },
   {
+    id: 'SubmitRedaction',
+    uiType: 'ohif.toolButton',
+    props: {
+      icon: 'Upload',
+      label: i18n.t('Buttons:Submit Redaction'),
+      tooltip: i18n.t('Buttons:Submit PHI Redaction'),
+      commands: 'submitRedactionPayload',
+      evaluate: 'evaluate.action',
+    },
+  },
+  {
     id: 'CircleROI',
     uiType: 'ohif.toolButton',
     props: {

--- a/modes/segmentation/src/index.tsx
+++ b/modes/segmentation/src/index.tsx
@@ -104,6 +104,7 @@ function modeFactory({ modeConfiguration }) {
         'Magnify',
         'TagBrowser',
         'OPFSTool',
+        'SubmitRedaction',
       ]);
 
       toolbarService.updateSection(toolbarService.sections.labelMapSegmentationToolbox, [
@@ -147,7 +148,7 @@ function modeFactory({ modeConfiguration }) {
 
       toolbarService.updateSection('BrushTools', ['Brush', 'Eraser', 'Threshold']);
 
-      toolbarService.updateSection('PHIBoundingBox', ['PHIBoundingBox', 'SubmitRedaction']);
+      toolbarService.updateSection('PHIBoundingBox', ['PHIBoundingBox']);
 
       // Making the 'cornerstone.panelTool' the default/first right panel will automaically
       // handle the evaluate functions for segmentation panel tools through the toolbox components.

--- a/modes/segmentation/src/index.tsx
+++ b/modes/segmentation/src/index.tsx
@@ -147,7 +147,7 @@ function modeFactory({ modeConfiguration }) {
 
       toolbarService.updateSection('BrushTools', ['Brush', 'Eraser', 'Threshold']);
 
-      toolbarService.updateSection('PHIBoundingBox', ['PHIBoundingBox']);
+      toolbarService.updateSection('PHIBoundingBox', ['PHIBoundingBox', 'SubmitRedaction']);
 
       // Making the 'cornerstone.panelTool' the default/first right panel will automaically
       // handle the evaluate functions for segmentation panel tools through the toolbox components.

--- a/modes/segmentation/src/index.tsx
+++ b/modes/segmentation/src/index.tsx
@@ -104,6 +104,7 @@ function modeFactory({ modeConfiguration }) {
         'Magnify',
         'TagBrowser',
         'OPFSTool',
+        'PHIBoundingBox',
         'SubmitRedaction',
       ]);
 

--- a/modes/segmentation/src/toolbarButtons.ts
+++ b/modes/segmentation/src/toolbarButtons.ts
@@ -1218,6 +1218,17 @@ export const toolbarButtons: Button[] = [
       evaluate: 'evaluate.cornerstoneTool',
     },
   },
+  {
+    id: 'SubmitRedaction',
+    uiType: 'ohif.toolButton',
+    props: {
+      icon: 'Upload',
+      label: i18n.t('Buttons:Submit Redaction'),
+      tooltip: i18n.t('Buttons:Submit PHI Redaction'),
+      commands: 'submitRedactionPayload',
+      evaluate: 'evaluate.action',
+    },
+  },
 ];
 
 export default toolbarButtons;


### PR DESCRIPTION
https://github.com/user-attachments/assets/bd80fabe-80a3-4f52-9543-c6492920fedc

### Context

Addresses [PROC-1577](https://linear.app/gradienthealth/issue/PROC-1577). Sister to [PROC-1576](https://linear.app/gradienthealth/issue/PROC-1576) (merged in `cloud_optimized_dicom`), which added a `redact_pixel_data` API that accepts integer-pixel `PixelRedaction` objects. PHI bounding boxes drawn in the viewer are stored as Cornerstone3D world coords with 1-based frame numbers, so the world→pixel transform belongs viewer-side where the image geometry is already loaded.

### Why postMessage instead of a direct POST from the viewer

Permissions handling and audit logging belong to review-service: it already authenticates the reviewer, knows which studies they're allowed to act on, and has Pulumi infrastructure in place for the backend it would call. A direct viewer→backend POST would mean re-solving auth on the viewer side (token plumbing, CORS, per-deploy endpoint config) and splitting the audit trail across two services. Posting up to the parent frame via `window.parent.postMessage` keeps the viewer dumb — it just produces a payload — and lets review-service own identity, authorization, and the call into COD end-to-end. The viewer fork already has this protocol in place (`seriesReady` / `loadSeries` in `usePostMessageSeriesSwitching.ts`, consumed in review-service's `ViewerPanel.tsx`), so we're extending an established channel rather than adding a new one.

### Changes

- **`extensions/cornerstone/src/utils/buildRedactionPayload.ts`** (new): pure helper that maps each `PHIBoundingBox` annotation's world points through `csUtils.worldToImageCoords`, integer-normalizes to top-left `(x, y, w, h)`, rejects out-of-bounds boxes via `RedactionOutOfBoundsError` (COD hard-errors on these), converts `frameNumber` 1-based → 0-based, and groups by `(geometry, frame-set)` so identical PHI redacted across a stack of single-frame slices collapses into one redaction with multiple `applies_to` UIDs.
- **`extensions/cornerstone/src/commandsModule.ts`**: new `submitRedactionPayload` command. Resolves the active study from the focused viewport, filters all `PHIBoundingBox` measurements to that study, groups by `referenceSeriesUID`, builds one payload per series, and fires `window.parent.postMessage({ type: 'phiRedactionSubmit', payload }, '*')` for each — one message per series. The build pass is atomic: any out-of-bounds box on any series aborts the whole submit before a single `postMessage` is sent. Errors before send (no active study, no PHI in study, out-of-bounds, not-embedded) surface via `uiNotificationService`; the success toast warns when annotations on other studies were skipped.
- **Toolbar buttons** (`modes/basic`, `modes/segmentation`): `SubmitRedaction` (Upload icon) and the existing `PHIBoundingBox` draw tool both live in the `MoreTools` overflow now. They were previously only consumed by the gradienthealth extension's `PHIBoxSection.tsx`, which renders inside the form panel — sheet-gated, and only iterates the first button anyway. review-service v2 doesn't use sheets and explicitly disables the side panels in its embedded prefetch iframes, so the form-panel placement was effectively dead. The MoreTools placement is reachable in v2's prefetch iframe, in the popped-out full viewer, and regardless of URL params or panel state.
- **Tests**: 9 unit tests for `buildRedactionPayload` covering happy path, float→int rounding, three out-of-bounds rejection paths, and the four grouping cases (same-UID multi-frame collapse, multi-UID single-frame collapse, mixed frame-set split, different-geometry preservation).

### Wire format

Mirrors the merged COD `PixelRedaction` dataclass so review-service can deserialize 1:1. One message is posted per series with PHI:

```ts
window.parent.postMessage(
  {
    type: 'phiRedactionSubmit',
    payload: {
      study_uid: '...',
      series_uid: '...',
      redactions: [
        { box: { x, y, width, height }, applies_to: ['<SOP UID>', ...], frames: [0, 5] },
      ],
    },
  },
  '*'
);
```

[PROC-1578](https://linear.app/gradienthealth/issue/PROC-1578) is now scoped as a review-service postMessage handler that calls COD, not a new HTTP endpoint.

### Testing

1. `cd extensions/cornerstone && yarn jest --testPathPattern=buildRedactionPayload` — 9 cases pass in ~1s.
2. Open the viewer in a parent page that listens for `event.data.type === 'phiRedactionSubmit'` (a tiny test harness lives in `.context/phi-redaction-test-parent.html` for local use).
3. Open the MoreTools (`...`) overflow in the toolbar — both `PHIBoundingBox` and `Submit Redaction` are at the bottom of the list.
4. Activate `PHIBoundingBox`, draw rectangles across one or more slices, in one or more series of the same study (multi-viewport layout to exercise fan-out).
5. Click `Submit Redaction`. Verify the parent receives one message per series with PHI; each `payload` matches the wire format above; integer coords; 0-based frames.
6. Edge cases — all confirmed manually: a box that exits image bounds error-toasts and emits no message (atomic abort across all series); zero boxes warn-toasts; running outside an iframe error-toasts; PHI on other studies is flagged in the success-toast tail and skipped.

### Known follow-up

[PROC-1641](https://linear.app/gradienthealth/issue/PROC-1641) tracks a UX affordance to stamp a freshly-drawn PHIBoundingBox onto a range of adjacent slices with pixel-identical coordinates. The grouping logic in this PR collapses identical boxes across slices into one redaction, but hand-drawn boxes essentially never round to identical corners, so in practice each cross-slice PHI box currently ships as its own redaction. Functionally fine — COD applies them per-instance regardless — but the wire format and audit trail compress nicely once the input boxes line up exactly, which is a UX problem rather than a payload-shape problem.