### PR TITLE
Add jump-to-first-rendered-slice dialog for dynamic volumes

### DIFF
--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useCallback, useState } from 'react';
 import * as cs3DTools from '@cornerstonejs/tools';
 import { Enums, eventTarget, getEnabledElement } from '@cornerstonejs/core';
 import { MeasurementService, useViewportRef } from '@ohif/core';
-import { useViewportDialog } from '@ohif/ui-next';
+import { useCine, useViewportDialog } from '@ohif/ui-next';
 import type { Types as csTypes } from '@cornerstonejs/core';
 
 import { setEnabledElement } from '../state';
@@ -69,14 +69,11 @@ const OHIFCornerstoneViewport = React.memo(
       displaySetOptions.push({});
     }
 
+    const isDynamicVolume = displaySets.some(ds => ds.isDynamicVolume && ds.isReconstructable);
     // Since we only have support for dynamic data in volume viewports, we should
     // handle this case here and set the viewportType to volume if any of the
     // displaySets are dynamic volumes
-    viewportOptions.viewportType = displaySets.some(
-      ds => ds.isDynamicVolume && ds.isReconstructable
-    )
-      ? 'volume'
-      : viewportOptions.viewportType;
+    viewportOptions.viewportType = isDynamicVolume ? 'volume' : viewportOptions.viewportType;
 
     const [scrollbarHeight, setScrollbarHeight] = useState('100px');
     const [enabledVPElement, setEnabledVPElement] = useState(null);
@@ -96,6 +93,11 @@ const OHIFCornerstoneViewport = React.memo(
     } = servicesManager.services;
 
     const [viewportDialogState] = useViewportDialog();
+    const [{ isCineEnabled }, cineService] = useCine();
+    const cineDialogPositioning = {
+      isCineVisibleOnViewport: isCineEnabled && !cineService.isViewportCineClosed(viewportId),
+      viewportDialogTopClass: isDynamicVolume ? 'top-[110px]' : 'top-[85px]',
+    };
     // useCallback for scroll bar height calculation
     const setImageScrollBarHeight = useCallback(() => {
       const scrollbarHeight = `${elementRef.current.clientHeight - 10}px`;
@@ -339,8 +341,16 @@ const OHIFCornerstoneViewport = React.memo(
             servicesManager={servicesManager}
           />
         </div>
-        {/* top offset of 24px to account for ViewportActionCorners. */}
-        <div className="absolute top-[24px] w-full">
+        {/* top offset of 24px to account for ViewportActionCorners.
+            When cine is open for this viewport, push below the cine bar (and the
+            dynamic-volume slice slider) so the dialog isn't occluded. */}
+        <div
+          className={`absolute z-50 w-full ${
+            cineDialogPositioning.isCineVisibleOnViewport
+              ? cineDialogPositioning.viewportDialogTopClass
+              : 'top-[24px]'
+          }`}
+        >
           {viewportDialogState.viewportId === viewportId && (
             <Notification
               id="viewport-notification"

--- a/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
@@ -209,7 +209,7 @@ function SmartImageScrollbar({
             targetViewport.render();
           }
         },
-        onOutsideClick: () => uiViewportDialogService.hide(),
+        onOutsideClick: () => {},
         onKeyPress: () => {},
       });
     };

--- a/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
@@ -1,10 +1,18 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { Enums, cache, eventTarget, utilities as csCoreUtils } from '@cornerstonejs/core';
+import { useTranslation } from 'react-i18next';
+import {
+  Enums,
+  cache,
+  eventTarget,
+  utilities as csCoreUtils,
+  StreamingDynamicImageVolume,
+  VolumeViewport,
+} from '@cornerstonejs/core';
 import { ImageScrollbar } from '@ohif/ui-next';
 import classNames from 'classnames';
 import { useCachedSlicesPerDisplaysetStore } from '../../stores';
-import { getFirstRenderedImageId } from './utils';
+import { getFirstRenderedSliceIndex } from '../../utils/getFirstRenderedSliceIndex';
 
 const KEYS = { Ctrl: 17 };
 
@@ -19,9 +27,11 @@ function SmartImageScrollbar({
 }: withAppTypes<{
   element: HTMLElement;
 }>) {
+  const { t } = useTranslation('Common');
   const [cachedImages, setCachedImages] = useState([]);
   const [isKeyPressed, setIsKeyPressed] = useState(false);
-  const hasHandledFirstImage = useRef(false);
+  const handledVolumeIds = useRef<Set<string>>(new Set());
+  const volumeFirstImageCache = useRef<Map<string, number>>(new Map());
 
   const { cineService, cornerstoneViewportService, uiViewportDialogService } =
     servicesManager.services;
@@ -136,11 +146,11 @@ function SmartImageScrollbar({
 
   useEffect(() => {
     const handleVolumeModified = evt => {
-      if (hasHandledFirstImage.current) {
+      const { volumeId } = evt.detail;
+
+      if (handledVolumeIds.current.has(volumeId)) {
         return;
       }
-
-      const { volumeId } = evt.detail;
 
       const renderingEngine = cornerstoneViewportService.getRenderingEngine();
       if (!renderingEngine) {
@@ -167,34 +177,38 @@ function SmartImageScrollbar({
         return;
       }
 
-      const numTimePoints = volume.numTimePoints || 1;
-      const slicesPerTimePoint = volume.imageIds.length / numTimePoints;
-
-      const groupImageIds = (volume as any).getCurrentDimensionGroupImageIds();
-      const firstRenderingImageId = getFirstRenderedImageId(groupImageIds);
-      const firstRenderingImageIdIndex = volume.imageIds.indexOf(firstRenderingImageId);
-
-      if (!firstRenderingImageId || !cache.isLoaded(firstRenderingImageId)) {
-        return;
+      let firstSliceIndex = volumeFirstImageCache.current.get(volumeId);
+      if (firstSliceIndex === undefined) {
+        const groupImageIds = (
+          volume as StreamingDynamicImageVolume
+        ).getCurrentDimensionGroupImageIds();
+        firstSliceIndex = getFirstRenderedSliceIndex(
+          groupImageIds,
+          targetViewport as VolumeViewport,
+          volumeId
+        );
+        if (firstSliceIndex === undefined) {
+          return;
+        }
+        volumeFirstImageCache.current.set(volumeId, firstSliceIndex);
       }
 
-      hasHandledFirstImage.current = true;
-      eventTarget.removeEventListener(Enums.Events.IMAGE_VOLUME_MODIFIED, handleVolumeModified);
+      handledVolumeIds.current.add(volumeId);
 
       uiViewportDialogService.show({
-        id: 'jump-to-loaded-slice',
+        id: `jump-to-loaded-slice-${viewportId}`,
         viewportId,
         type: 'info',
-        message: `A slice in the group has been rendered. Jump to it?`,
+        message: t('A slice in the group has been rendered. Jump to it?'),
         actions: [
-          { id: 'no', type: 'secondary', text: 'No', value: false },
-          { id: 'yes', type: 'primary', text: 'Yes', value: true },
+          { id: 'no', type: 'secondary', text: t('No'), value: false },
+          { id: 'yes', type: 'primary', text: t('Yes'), value: true },
         ],
         onSubmit: (result: boolean) => {
           uiViewportDialogService.hide();
           if (result) {
             csCoreUtils.jumpToSlice(targetViewport.element, {
-              imageIndex: firstRenderingImageIdIndex % slicesPerTimePoint,
+              imageIndex: firstSliceIndex,
               volumeId,
             });
             targetViewport.render();

--- a/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Enums, cache, eventTarget, utilities as csCoreUtils } from '@cornerstonejs/core';
 import { ImageScrollbar } from '@ohif/ui-next';
 import classNames from 'classnames';
 import { useCachedSlicesPerDisplaysetStore } from '../../stores';
+import { getFirstRenderedImageId } from './utils';
 
 const KEYS = { Ctrl: 17 };
 
@@ -20,8 +21,10 @@ function SmartImageScrollbar({
 }>) {
   const [cachedImages, setCachedImages] = useState([]);
   const [isKeyPressed, setIsKeyPressed] = useState(false);
+  const hasHandledFirstImage = useRef(false);
 
-  const { cineService, cornerstoneViewportService } = servicesManager.services;
+  const { cineService, cornerstoneViewportService, uiViewportDialogService } =
+    servicesManager.services;
   const numOfSlices = imageSliceData.numberOfSlices;
   const scrollbarHeightValue = +scrollbarHeight.split('px')[0] + 2;
   const isStackViewport = viewportData?.viewportType === Enums.ViewportType.STACK;
@@ -130,6 +133,84 @@ function SmartImageScrollbar({
       window.removeEventListener('keyup', onKeyUp);
     };
   }, []);
+
+  useEffect(() => {
+    const handleVolumeModified = evt => {
+      if (hasHandledFirstImage.current) {
+        return;
+      }
+
+      const { volumeId } = evt.detail;
+
+      const renderingEngine = cornerstoneViewportService.getRenderingEngine();
+      if (!renderingEngine) {
+        return;
+      }
+
+      const targetViewport = renderingEngine.getViewport(viewportId);
+      if (
+        !targetViewport ||
+        (targetViewport.type !== Enums.ViewportType.ORTHOGRAPHIC &&
+          targetViewport.type !== Enums.ViewportType.VOLUME_3D)
+      ) {
+        return;
+      }
+
+      const actors = targetViewport.getActors();
+      const belongsToViewport = actors.some(actor => actor.referencedId === volumeId);
+      if (!belongsToViewport) {
+        return;
+      }
+
+      const volume = cache.getVolume(volumeId);
+      if (!volume?.imageIds || !volume.isDynamicVolume()) {
+        return;
+      }
+
+      const numTimePoints = volume.numTimePoints || 1;
+      const slicesPerTimePoint = volume.imageIds.length / numTimePoints;
+
+      const groupImageIds = (volume as any).getCurrentDimensionGroupImageIds();
+      const firstRenderingImageId = getFirstRenderedImageId(groupImageIds);
+      const firstRenderingImageIdIndex = volume.imageIds.indexOf(firstRenderingImageId);
+
+      if (!firstRenderingImageId || !cache.isLoaded(firstRenderingImageId)) {
+        return;
+      }
+
+      hasHandledFirstImage.current = true;
+      eventTarget.removeEventListener(Enums.Events.IMAGE_VOLUME_MODIFIED, handleVolumeModified);
+
+      uiViewportDialogService.show({
+        id: 'jump-to-loaded-slice',
+        viewportId,
+        type: 'info',
+        message: `A slice in the group has been rendered. Jump to it?`,
+        actions: [
+          { id: 'no', type: 'secondary', text: 'No', value: false },
+          { id: 'yes', type: 'primary', text: 'Yes', value: true },
+        ],
+        onSubmit: (result: boolean) => {
+          uiViewportDialogService.hide();
+          if (result) {
+            csCoreUtils.jumpToSlice(targetViewport.element, {
+              imageIndex: firstRenderingImageIdIndex % slicesPerTimePoint,
+              volumeId,
+            });
+            targetViewport.render();
+          }
+        },
+        onOutsideClick: () => uiViewportDialogService.hide(),
+        onKeyPress: () => {},
+      });
+    };
+
+    eventTarget.addEventListener(Enums.Events.IMAGE_VOLUME_MODIFIED, handleVolumeModified);
+
+    return () => {
+      eventTarget.removeEventListener(Enums.Events.IMAGE_VOLUME_MODIFIED, handleVolumeModified);
+    };
+  }, [viewportId]);
 
   function updateCachedSlices() {
     if (!viewportData?.data) {

--- a/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
@@ -31,7 +31,6 @@ function SmartImageScrollbar({
   const [cachedImages, setCachedImages] = useState([]);
   const [isKeyPressed, setIsKeyPressed] = useState(false);
   const handledVolumeIds = useRef<Set<string>>(new Set());
-  const volumeFirstImageCache = useRef<Map<string, number>>(new Map());
 
   const { cineService, cornerstoneViewportService, uiViewportDialogService } =
     servicesManager.services;
@@ -177,20 +176,16 @@ function SmartImageScrollbar({
         return;
       }
 
-      let firstSliceIndex = volumeFirstImageCache.current.get(volumeId);
+      const groupImageIds = (
+        volume as StreamingDynamicImageVolume
+      ).getCurrentDimensionGroupImageIds();
+      const firstSliceIndex = getFirstRenderedSliceIndex(
+        groupImageIds,
+        targetViewport as VolumeViewport,
+        volumeId
+      );
       if (firstSliceIndex === undefined) {
-        const groupImageIds = (
-          volume as StreamingDynamicImageVolume
-        ).getCurrentDimensionGroupImageIds();
-        firstSliceIndex = getFirstRenderedSliceIndex(
-          groupImageIds,
-          targetViewport as VolumeViewport,
-          volumeId
-        );
-        if (firstSliceIndex === undefined) {
-          return;
-        }
-        volumeFirstImageCache.current.set(volumeId, firstSliceIndex);
+        return;
       }
 
       handledVolumeIds.current.add(volumeId);

--- a/extensions/cornerstone/src/Viewport/Overlays/utils.ts
+++ b/extensions/cornerstone/src/Viewport/Overlays/utils.ts
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import i18n from 'i18next';
-import { vec3 } from 'gl-matrix';
 import { metaData } from '@cornerstonejs/core';
 import { formatDICOMDate } from '@ohif/ui-next';
 
@@ -62,48 +61,6 @@ export function getCompression(imageId) {
   }
 
   return 'Lossless / Uncompressed';
-}
-
-/**
- * Returns the imageId that will render first during streaming for a dimension group.
- * The first-rendered slice is determined by which end of the group sortImageIdsAndGetSpacing
- * places at the front of its descending sort — whichever imageId ends up with the
- * largest projection distance from the reference (imageIds[0]).
- *
- * @param imageIds - imageIds for a single dimension group
- * @returns The imageId that will be requested and rendered first
- */
-export function getFirstRenderedImageId(imageIds: string[]): string {
-  if (imageIds.length === 1) {
-    return imageIds[0];
-  }
-
-  const metadata0 = metaData.get('imagePlaneModule', imageIds[0]);
-  const metadata1 = metaData.get('imagePlaneModule', imageIds[1]);
-
-  if (
-    !metadata0?.imagePositionPatient ||
-    !metadata0?.imageOrientationPatient ||
-    !metadata1?.imagePositionPatient
-  ) {
-    console.warn('Missing image plane metadata. Defaulting to first imageId.');
-    return imageIds[0];
-  }
-
-  const { imagePositionPatient: pos0, imageOrientationPatient } = metadata0;
-  const { imagePositionPatient: pos1 } = metadata1;
-
-  const rowCosine = vec3.fromValues(...imageOrientationPatient.slice(0, 3));
-  const colCosine = vec3.fromValues(...imageOrientationPatient.slice(3, 6));
-  const scanAxisNormal = vec3.create();
-  vec3.cross(scanAxisNormal, rowCosine, colCosine);
-
-  // Vector from first instance to second instance
-  const step = vec3.sub(vec3.create(), pos1, pos0);
-
-  // dot > 0 → imageIds go in the scan direction → imageIds[0] is last physical slice → last imageId renders first
-  // dot < 0 → imageIds go against the scan direction → imageIds[0] is first physical slice → first imageId renders first
-  return vec3.dot(step, scanAxisNormal) > 0 ? imageIds[imageIds.length - 1] : imageIds[0];
 }
 
 export { formatDICOMDate };

--- a/extensions/cornerstone/src/Viewport/Overlays/utils.ts
+++ b/extensions/cornerstone/src/Viewport/Overlays/utils.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import i18n from 'i18next';
+import { vec3 } from 'gl-matrix';
 import { metaData } from '@cornerstonejs/core';
 import { formatDICOMDate } from '@ohif/ui-next';
 
@@ -61,6 +62,48 @@ export function getCompression(imageId) {
   }
 
   return 'Lossless / Uncompressed';
+}
+
+/**
+ * Returns the imageId that will render first during streaming for a dimension group.
+ * The first-rendered slice is determined by which end of the group sortImageIdsAndGetSpacing
+ * places at the front of its descending sort — whichever imageId ends up with the
+ * largest projection distance from the reference (imageIds[0]).
+ *
+ * @param imageIds - imageIds for a single dimension group
+ * @returns The imageId that will be requested and rendered first
+ */
+export function getFirstRenderedImageId(imageIds: string[]): string {
+  if (imageIds.length === 1) {
+    return imageIds[0];
+  }
+
+  const metadata0 = metaData.get('imagePlaneModule', imageIds[0]);
+  const metadata1 = metaData.get('imagePlaneModule', imageIds[1]);
+
+  if (
+    !metadata0?.imagePositionPatient ||
+    !metadata0?.imageOrientationPatient ||
+    !metadata1?.imagePositionPatient
+  ) {
+    console.warn('Missing image plane metadata. Defaulting to first imageId.');
+    return imageIds[0];
+  }
+
+  const { imagePositionPatient: pos0, imageOrientationPatient } = metadata0;
+  const { imagePositionPatient: pos1 } = metadata1;
+
+  const rowCosine = vec3.fromValues(...imageOrientationPatient.slice(0, 3));
+  const colCosine = vec3.fromValues(...imageOrientationPatient.slice(3, 6));
+  const scanAxisNormal = vec3.create();
+  vec3.cross(scanAxisNormal, rowCosine, colCosine);
+
+  // Vector from first instance to second instance
+  const step = vec3.sub(vec3.create(), pos1, pos0);
+
+  // dot > 0 → imageIds go in the scan direction → imageIds[0] is last physical slice → last imageId renders first
+  // dot < 0 → imageIds go against the scan direction → imageIds[0] is first physical slice → first imageId renders first
+  return vec3.dot(step, scanAxisNormal) > 0 ? imageIds[imageIds.length - 1] : imageIds[0];
 }
 
 export { formatDICOMDate };

--- a/extensions/cornerstone/src/utils/getFirstRenderedSliceIndex.test.ts
+++ b/extensions/cornerstone/src/utils/getFirstRenderedSliceIndex.test.ts
@@ -1,0 +1,139 @@
+import { getFirstRenderedSliceIndex } from './getFirstRenderedSliceIndex';
+import type { VolumeViewport } from '@cornerstonejs/core';
+
+const mockIsLoaded = jest.fn();
+const mockMetaDataGet = jest.fn();
+const mockGetVolumeSliceRangeInfo = jest.fn();
+
+jest.mock('@cornerstonejs/core', () => ({
+  cache: {
+    isLoaded: (...args: any[]) => mockIsLoaded(...args),
+  },
+  metaData: {
+    get: (...args: any[]) => mockMetaDataGet(...args),
+  },
+  utilities: {
+    getVolumeSliceRangeInfo: (...args: any[]) => mockGetVolumeSliceRangeInfo(...args),
+  },
+  VolumeViewport: class {},
+}));
+
+const makeViewport = (viewPlaneNormal: number[]) =>
+  ({ getCamera: () => ({ viewPlaneNormal }) }) as VolumeViewport;
+
+const VOLUME_ID = 'volume-1';
+
+describe('getFirstRenderedSliceIndex', () => {
+  afterEach(() => {
+    mockIsLoaded.mockReset();
+    mockMetaDataGet.mockReset();
+    mockGetVolumeSliceRangeInfo.mockReset();
+  });
+
+  it('returns undefined for an empty imageIds array', () => {
+    const result = getFirstRenderedSliceIndex([], makeViewport([0, 0, -1]), VOLUME_ID);
+    expect(result).toBeUndefined();
+    expect(mockIsLoaded).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the single imageId is not loaded', () => {
+    mockIsLoaded.mockReturnValue(false);
+    const result = getFirstRenderedSliceIndex(['img1'], makeViewport([0, 0, -1]), VOLUME_ID);
+    expect(result).toBeUndefined();
+    expect(mockMetaDataGet).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when neither first nor last imageId is loaded', () => {
+    mockIsLoaded.mockReturnValue(false);
+    const result = getFirstRenderedSliceIndex(
+      ['img1', 'img2', 'img3'],
+      makeViewport([0, 0, -1]),
+      VOLUME_ID
+    );
+    expect(result).toBeUndefined();
+    expect(mockIsLoaded).toHaveBeenCalledWith('img1');
+    expect(mockIsLoaded).toHaveBeenCalledWith('img3');
+    expect(mockMetaDataGet).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when metadata is unavailable for the loaded imageId', () => {
+    mockIsLoaded.mockReturnValue(true);
+    mockMetaDataGet.mockReturnValue(null);
+    mockGetVolumeSliceRangeInfo.mockReturnValue({
+      sliceRange: { min: 0, max: 10 },
+      spacingInNormalDirection: 1,
+    });
+    const result = getFirstRenderedSliceIndex(['img1'], makeViewport([0, 0, -1]), VOLUME_ID);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when sliceRangeInfo is unavailable', () => {
+    mockIsLoaded.mockReturnValue(true);
+    mockMetaDataGet.mockReturnValue({ imagePositionPatient: [0, 0, 5] });
+    mockGetVolumeSliceRangeInfo.mockReturnValue(null);
+    const result = getFirstRenderedSliceIndex(['img1'], makeViewport([0, 0, -1]), VOLUME_ID);
+    expect(result).toBeUndefined();
+  });
+
+  it('uses the first imageId when it is loaded', () => {
+    mockIsLoaded.mockImplementation(imageId => imageId === 'img1');
+    mockMetaDataGet.mockReturnValue({ imagePositionPatient: [0, 0, 10] });
+    mockGetVolumeSliceRangeInfo.mockReturnValue({
+      sliceRange: { min: -10, max: 10 },
+      spacingInNormalDirection: 1,
+    });
+    // viewPlaneNormal = [0,0,-1], IPP = [0,0,10]
+    // projected = 10 * -1 = -10
+    // index = round((-10 - (-10)) / 1) = 0
+    const viewport = makeViewport([0, 0, -1]);
+    const result = getFirstRenderedSliceIndex(['img1', 'img2'], viewport, VOLUME_ID);
+    expect(mockIsLoaded).toHaveBeenCalledWith('img1');
+    expect(mockMetaDataGet).toHaveBeenCalledWith('imagePlaneModule', 'img1');
+    expect(result).toBe(0);
+  });
+
+  it('uses the last imageId when only the last is loaded', () => {
+    mockIsLoaded.mockImplementation(imageId => imageId === 'img3');
+    mockMetaDataGet.mockReturnValue({ imagePositionPatient: [0, 0, -10] });
+    mockGetVolumeSliceRangeInfo.mockReturnValue({
+      sliceRange: { min: -10, max: 10 },
+      spacingInNormalDirection: 1,
+    });
+    // viewPlaneNormal = [0,0,-1], IPP = [0,0,-10]
+    // projected = -10 * -1 = 10
+    // index = round((10 - (-10)) / 1) = 20
+    const viewport = makeViewport([0, 0, -1]);
+    const result = getFirstRenderedSliceIndex(['img1', 'img2', 'img3'], viewport, VOLUME_ID);
+    expect(mockIsLoaded).toHaveBeenCalledWith('img1');
+    expect(mockIsLoaded).toHaveBeenCalledWith('img3');
+    expect(mockMetaDataGet).toHaveBeenCalledWith('imagePlaneModule', 'img3');
+    expect(result).toBe(20);
+  });
+
+  it('prefers the first imageId when both ends are loaded', () => {
+    mockIsLoaded.mockReturnValue(true);
+    mockMetaDataGet.mockReturnValue({ imagePositionPatient: [0, 0, 5] });
+    mockGetVolumeSliceRangeInfo.mockReturnValue({
+      sliceRange: { min: 0, max: 10 },
+      spacingInNormalDirection: 1,
+    });
+    getFirstRenderedSliceIndex(['img1', 'img2', 'img3'], makeViewport([0, 0, 1]), VOLUME_ID);
+    expect(mockIsLoaded).toHaveBeenCalledTimes(1);
+    expect(mockIsLoaded).toHaveBeenCalledWith('img1');
+    expect(mockMetaDataGet).toHaveBeenCalledWith('imagePlaneModule', 'img1');
+  });
+
+  it('calculates the correct slice index via geometric projection', () => {
+    mockIsLoaded.mockReturnValue(true);
+    // Axial: viewPlaneNormal = [0,0,-1], IPP z = -5
+    // projected = -5 * -1 = 5
+    // index = round((5 - 0) / 2.5) = 2
+    mockMetaDataGet.mockReturnValue({ imagePositionPatient: [0, 0, -5] });
+    mockGetVolumeSliceRangeInfo.mockReturnValue({
+      sliceRange: { min: 0, max: 10 },
+      spacingInNormalDirection: 2.5,
+    });
+    const result = getFirstRenderedSliceIndex(['img1'], makeViewport([0, 0, -1]), VOLUME_ID);
+    expect(result).toBe(2);
+  });
+});

--- a/extensions/cornerstone/src/utils/getFirstRenderedSliceIndex.ts
+++ b/extensions/cornerstone/src/utils/getFirstRenderedSliceIndex.ts
@@ -1,0 +1,51 @@
+import { cache, metaData, utilities as csCoreUtils, VolumeViewport } from '@cornerstonejs/core';
+
+/**
+ * Finds the first loaded imageId in the dimension group (checking both ends, since
+ * server-side WADO-RS frame delivery order is unpredictable) and returns its viewport
+ * slice index via geometric projection. Returns undefined if neither end is cached yet
+ * or if metadata/sliceRange is unavailable.
+ *
+ * @param imageIds - imageIds for a single dimension group
+ * @param viewport - the volume viewport
+ * @param volumeId - volumeId associated with the viewport
+ */
+export function getFirstRenderedSliceIndex(
+  imageIds: string[],
+  viewport: VolumeViewport,
+  volumeId: string
+): number | undefined {
+  if (imageIds.length === 0) {
+    return undefined;
+  }
+
+  let imageId: string | undefined;
+  if (imageIds.length === 1) {
+    imageId = cache.isLoaded(imageIds[0]) ? imageIds[0] : undefined;
+  } else if (cache.isLoaded(imageIds[0])) {
+    imageId = imageIds[0];
+  } else if (cache.isLoaded(imageIds[imageIds.length - 1])) {
+    imageId = imageIds[imageIds.length - 1];
+  }
+
+  if (!imageId) {
+    return undefined;
+  }
+
+  const { imagePositionPatient } = metaData.get('imagePlaneModule', imageId) || {};
+  const { viewPlaneNormal } = viewport.getCamera();
+  const sliceRangeInfo = csCoreUtils.getVolumeSliceRangeInfo(viewport, volumeId);
+
+  if (!imagePositionPatient || !viewPlaneNormal || !sliceRangeInfo) {
+    return undefined;
+  }
+
+  const projected =
+    imagePositionPatient[0] * viewPlaneNormal[0] +
+    imagePositionPatient[1] * viewPlaneNormal[1] +
+    imagePositionPatient[2] * viewPlaneNormal[2];
+
+  return Math.round(
+    (projected - sliceRangeInfo.sliceRange.min) / sliceRangeInfo.spacingInNormalDirection
+  );
+}


### PR DESCRIPTION
## Summary

- When streaming a dynamic volume (e.g. 4D cardiac), frames load progressively and the viewport starts at the default slice which may take time to render. This adds a dialog that detects when the first frame of the current dimension group has loaded and prompts the user to jump to it.
- Slice index is calculated using geometric projection against the viewport's view plane normal, matching Cornerstone's internal mapping of 3D positions to slice indices.
- Offset the dialog below the cine bar + slice slider so it isn't occluded.

## Demo

https://github.com/user-attachments/assets/11afa3f5-06c4-4d1d-872c-bffe7272008c

## Changes

- Added `IMAGE_VOLUME_MODIFIED` event listener in `SmartImageScrollbar` that fires when a frame is decoded during streaming
- Added `getFirstRenderedSliceIndex` util that detects the first cached imageId in a dimension group and computes the correct viewport slice index via geometric projection against `viewPlaneNormal`
- Tracks handled volumes with `handledVolumeIds: Set<string>` so loading a different volume in the same viewport re-triggers the dialog
- Namespaced dialog id with `viewportId`
- Wrapped strings with `t()` for i18n
- Added unit tests for `getFirstRenderedSliceIndex` covering all branches and projection math

## Test plan

- [ ] Load a 4D dynamic volume and verify the dialog appears when the first frame renders
- [ ] Confirm the dialog renders below the cine player, not behind it.
- [ ] Click **Yes** — confirm viewport jumps to the correct rendered slice
- [ ] Click **No** — confirm viewport stays at current position
- [ ] Load a second dynamic volume in the same viewport — confirm dialog re-triggers
- [ ] Verify no dialog appears for non-dynamic (stack/static) volumes
