### PR TITLE
Skip first-rendered-slice dialog when current slice is already loaded

### DIFF
--- a/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
@@ -156,12 +156,8 @@ function SmartImageScrollbar({
         return;
       }
 
-      const targetViewport = renderingEngine.getViewport(viewportId);
-      if (
-        !targetViewport ||
-        (targetViewport.type !== Enums.ViewportType.ORTHOGRAPHIC &&
-          targetViewport.type !== Enums.ViewportType.VOLUME_3D)
-      ) {
+      const targetViewport = renderingEngine.getViewport(viewportId) as VolumeViewport;
+      if (!targetViewport || targetViewport.type !== Enums.ViewportType.ORTHOGRAPHIC) {
         return;
       }
 
@@ -179,11 +175,14 @@ function SmartImageScrollbar({
       const groupImageIds = (
         volume as StreamingDynamicImageVolume
       ).getCurrentDimensionGroupImageIds();
-      const firstSliceIndex = getFirstRenderedSliceIndex(
-        groupImageIds,
-        targetViewport as VolumeViewport,
-        volumeId
-      );
+
+      const currentImageId = targetViewport.getCurrentImageId();
+      if (currentImageId && cache.isLoaded(currentImageId)) {
+        handledVolumeIds.current.add(volumeId);
+        return;
+      }
+
+      const firstSliceIndex = getFirstRenderedSliceIndex(groupImageIds, targetViewport, volumeId);
       if (firstSliceIndex === undefined) {
         return;
       }


### PR DESCRIPTION
## Summary
- Skip the jump-to-first-rendered-slice dialog when the viewport's current
  imageId is already in the image cache — avoids redundant prompts on
  fast-loading dynamic volumes where the middle slice renders instantly.
- Drop VOLUME_3D from the dialog's viewport-type gate; it isn't a slice-
  navigable viewport.