### PR TITLE
Auto-scroll through dynamic volume slices on load completion

### DIFF
--- a/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
@@ -169,6 +169,17 @@ function SmartImageScrollbar({
         return;
       }
 
+      if (
+        activeDialogVolumeIdRef.current === volumeId &&
+        dialogStateRef.current?.id === firstLoadedDialogId
+      ) {
+        const currentImageId = targetViewport.getCurrentImageId();
+        if (currentImageId && cache.isLoaded(currentImageId)) {
+          activeDialogVolumeIdRef.current = null;
+          uiViewportDialogService.hide();
+        }
+      }
+
       const actors = targetViewport.getActors();
       const belongsToViewport = actors.some(actor => actor.referencedId === volumeId);
 
@@ -179,17 +190,6 @@ function SmartImageScrollbar({
       if (numberOfFrames >= framesProcessed && numberOfFrames > 0) {
         const percent = Math.floor((framesProcessed / numberOfFrames) * 100);
         setRenderProgress(percent >= 100 ? null : percent);
-      }
-
-      if (
-        activeDialogVolumeIdRef.current === volumeId &&
-        dialogStateRef.current?.id === firstLoadedDialogId
-      ) {
-        const currentImageId = targetViewport.getCurrentImageId();
-        if (currentImageId && cache.isLoaded(currentImageId)) {
-          activeDialogVolumeIdRef.current = null;
-          uiViewportDialogService.hide();
-        }
       }
 
       if (handledVolumeIds.current.has(volumeId)) {
@@ -248,8 +248,9 @@ function SmartImageScrollbar({
 
     return () => {
       eventTarget.removeEventListener(Enums.Events.IMAGE_VOLUME_MODIFIED, handleVolumeModified);
+      setRenderProgress(null);
     };
-  }, [viewportId]);
+  }, [viewportId, viewportData]);
 
   useEffect(() => {
     const onVolumeLoadingCompleted = evt => {

--- a/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/SmartImageScrollbar.tsx
@@ -13,6 +13,7 @@ import { ImageScrollbar, useViewportDialog } from '@ohif/ui-next';
 import classNames from 'classnames';
 import { useCachedSlicesPerDisplaysetStore } from '../../stores';
 import { getFirstRenderedSliceIndex } from '../../utils/getFirstRenderedSliceIndex';
+import { activateAutoScroll, stopAutoScroll } from '../../utils/dynamicVolumeAutoScroll';
 
 const KEYS = { Ctrl: 17 };
 
@@ -26,10 +27,12 @@ function SmartImageScrollbar({
   servicesManager,
 }: withAppTypes<{
   element: HTMLElement;
+  viewportId: string;
 }>) {
   const { t } = useTranslation('Common');
   const [cachedImages, setCachedImages] = useState([]);
   const [isKeyPressed, setIsKeyPressed] = useState(false);
+  const [renderProgress, setRenderProgress] = useState<number | null>(null);
   const handledVolumeIds = useRef<Set<string>>(new Set());
   const activeDialogVolumeIdRef = useRef<string | null>(null);
   const [viewportDialogState] = useViewportDialog() || [];
@@ -154,7 +157,7 @@ function SmartImageScrollbar({
 
   useEffect(() => {
     const handleVolumeModified = evt => {
-      const { volumeId } = evt.detail;
+      const { volumeId, numberOfFrames, framesProcessed } = evt.detail;
 
       const renderingEngine = cornerstoneViewportService.getRenderingEngine();
       if (!renderingEngine) {
@@ -164,6 +167,18 @@ function SmartImageScrollbar({
       const targetViewport = renderingEngine.getViewport(viewportId) as VolumeViewport;
       if (!targetViewport || targetViewport.type !== Enums.ViewportType.ORTHOGRAPHIC) {
         return;
+      }
+
+      const actors = targetViewport.getActors();
+      const belongsToViewport = actors.some(actor => actor.referencedId === volumeId);
+
+      if (!belongsToViewport) {
+        return;
+      }
+
+      if (numberOfFrames >= framesProcessed && numberOfFrames > 0) {
+        const percent = Math.floor((framesProcessed / numberOfFrames) * 100);
+        setRenderProgress(percent >= 100 ? null : percent);
       }
 
       if (
@@ -178,12 +193,6 @@ function SmartImageScrollbar({
       }
 
       if (handledVolumeIds.current.has(volumeId)) {
-        return;
-      }
-
-      const actors = targetViewport.getActors();
-      const belongsToViewport = actors.some(actor => actor.referencedId === volumeId);
-      if (!belongsToViewport) {
         return;
       }
 
@@ -242,6 +251,36 @@ function SmartImageScrollbar({
     };
   }, [viewportId]);
 
+  useEffect(() => {
+    const onVolumeLoadingCompleted = evt => {
+      const { volumeId } = evt.detail;
+      const viewport = cornerstoneViewportService.getCornerstoneViewport(viewportId);
+      if (!viewport?.getActors) {
+        return;
+      }
+
+      const belongsToViewport = viewport.getActors().some(actor => actor.referencedId === volumeId);
+      if (!belongsToViewport) {
+        return;
+      }
+
+      activateAutoScroll({ servicesManager, viewportId });
+    };
+
+    eventTarget.addEventListener(
+      Enums.Events.IMAGE_VOLUME_LOADING_COMPLETED,
+      onVolumeLoadingCompleted
+    );
+
+    return () => {
+      eventTarget.removeEventListener(
+        Enums.Events.IMAGE_VOLUME_LOADING_COMPLETED,
+        onVolumeLoadingCompleted
+      );
+      stopAutoScroll({ servicesManager, viewportId });
+    };
+  }, [viewportId]);
+
   function updateCachedSlices() {
     if (!viewportData?.data) {
       return;
@@ -263,6 +302,11 @@ function SmartImageScrollbar({
 
   return (
     <>
+      {renderProgress !== null && (
+        <span className="text-primary-light absolute right-[20px] top-[15px] text-[14px] font-medium">
+          {renderProgress}%
+        </span>
+      )}
       {cachedImages.length && isStackViewport && (
         <span
           className="border-primary-light bg-secondary-active absolute right-[3px] top-[4px] w-3 overflow-hidden rounded-lg border"

--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -47,7 +47,9 @@ import {
   useSelectedSegmentationsForViewportStore,
   useCachedSlicesPerDisplaysetStore,
   useSegmentationSavingStatusStore,
+  useDynamicAutoScrollStore,
 } from './stores';
+import { stopAllAutoScroll } from './utils/dynamicVolumeAutoScroll';
 import { useToggleOneUpViewportGridStore } from '@ohif/extension-default';
 import { useActiveViewportSegmentationRepresentations } from './hooks/useActiveViewportSegmentationRepresentations';
 import { useMeasurements } from './hooks/useMeasurements';
@@ -156,6 +158,7 @@ const cornerstoneExtension: Types.Extensions.Extension = {
     cineService.setIsCineEnabled(false);
 
     enabledElementReset();
+    stopAllAutoScroll();
 
     useLutPresentationStore.getState().clearLutPresentationStore();
     usePositionPresentationStore.getState().clearPositionPresentationStore();
@@ -167,6 +170,7 @@ const cornerstoneExtension: Types.Extensions.Extension = {
     //   .clearSelectedSegmentationsForViewportStore();
     useCachedSlicesPerDisplaysetStore.getState().clearCachedSlicesPerDisplaysetStore();
     useSegmentationSavingStatusStore.getState().clearSegmentationSavingStatusMap();
+    useDynamicAutoScrollStore.getState().clearDynamicAutoScrollStore();
     segmentationService.removeAllSegmentations();
   },
 

--- a/extensions/cornerstone/src/stores/index.ts
+++ b/extensions/cornerstone/src/stores/index.ts
@@ -5,3 +5,4 @@ export { useSynchronizersStore } from './useSynchronizersStore';
 export { useSelectedSegmentationsForViewportStore } from './useSelectedSegmentationsForViewportStore';
 export { useCachedSlicesPerDisplaysetStore } from './useCachedSlicesPerSeriesStore';
 export { useSegmentationSavingStatusStore } from './useSegmentationSavingStatusStore';
+export { useDynamicAutoScrollStore } from './useDynamicAutoScrollStore';

--- a/extensions/cornerstone/src/stores/useDynamicAutoScrollStore.ts
+++ b/extensions/cornerstone/src/stores/useDynamicAutoScrollStore.ts
@@ -1,34 +1,18 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-/**
- * Identifier for the Dynamic Auto Scroll store type.
- */
 const PRESENTATION_TYPE_ID = 'dynamicAutoScrollStoreId';
-
-/**
- * Flag to enable or disable debug mode for the store.
- * Set to `true` to enable zustand devtools.
- */
 const DEBUG_STORE = false;
 
-/**
- * State shape for the Dynamic Auto Scroll store.
- */
 type DynamicAutoScrollState = {
-  /**
-   * Type identifier for the store.
-   */
   type: string;
 
-  /**
-   * Viewports with auto-scroll currently active, keyed by viewportId.
-   */
+  /** Viewports with auto-scroll currently active, keyed by viewportId. */
   autoActive: Record<string, boolean>;
 
   /**
    * Viewports where auto-scroll has been permanently disabled (e.g. after a user scroll),
-   * keyed by viewportId. Prevents re-activation for the rest of the session.
+   * keyed by viewportId. Prevents re-activation for the rest of the mode session.
    */
   permanentlyDisabled: Record<string, boolean>;
 
@@ -38,68 +22,40 @@ type DynamicAutoScrollState = {
    */
   selfScroll: Record<string, boolean>;
 
-  /**
-   * Marks auto-scroll as active for the given viewport.
-   */
+  /** Marks auto-scroll as active for the given viewport. */
   markAutoActive: (viewportId: string) => void;
 
-  /**
-   * Clears the active flag for the given viewport.
-   */
+  /** Clears the active flag for the given viewport.*/
   clearAutoActive: (viewportId: string) => void;
 
-  /**
-   * Returns whether auto-scroll is active for the given viewport.
-   */
+  /** Returns whether auto-scroll is active for the given viewport. */
   isAutoActive: (viewportId: string) => boolean;
 
-  /**
-   * Marks the given viewport as permanently opted out of auto-scroll.
-   */
+  /** Marks the given viewport as permanently opted out of auto-scroll. */
   markPermanentlyDisabled: (viewportId: string) => void;
 
-  /**
-   * Returns whether the given viewport is permanently opted out of auto-scroll.
-   */
+  /** Returns whether the given viewport is permanently opted out of auto-scroll. */
   isPermanentlyDisabled: (viewportId: string) => boolean;
 
-  /**
-   * Marks the next VOLUME_NEW_IMAGE on the given viewport as programmatic (self-driven).
-   */
+  /** Marks the next VOLUME_NEW_IMAGE on the given viewport as programmatic (self-driven). */
   markSelfScroll: (viewportId: string) => void;
 
-  /**
-   * Clears the self-scroll flag for the given viewport.
-   */
+  /** Clears the self-scroll flag for the given viewport. */
   clearSelfScroll: (viewportId: string) => void;
 
-  /**
-   * Returns whether the given viewport currently has a pending self-scroll.
-   */
+  /** Returns whether the given viewport currently has a pending self-scroll. */
   isSelfScroll: (viewportId: string) => boolean;
 
-  /**
-   * Clears the entire Dynamic Auto Scroll store.
-   */
+  /** Clears the entire Dynamic Auto Scroll store. */
   clearDynamicAutoScrollStore: () => void;
 };
 
-/**
- * Creates the Dynamic Auto Scroll store.
- *
- * @param set - The zustand set function.
- * @param get - The zustand get function.
- * @returns The Dynamic Auto Scroll store state and actions.
- */
 const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
   type: PRESENTATION_TYPE_ID,
   autoActive: {},
   permanentlyDisabled: {},
   selfScroll: {},
 
-  /**
-   * Marks auto-scroll as active for the given viewport.
-   */
   markAutoActive: viewportId =>
     set(
       state => ({ autoActive: { ...state.autoActive, [viewportId]: true } }),
@@ -107,9 +63,6 @@ const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
       'markAutoActive'
     ),
 
-  /**
-   * Clears the active flag for the given viewport.
-   */
   clearAutoActive: viewportId =>
     set(
       state => {
@@ -121,14 +74,8 @@ const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
       'clearAutoActive'
     ),
 
-  /**
-   * Returns whether auto-scroll is active for the given viewport.
-   */
   isAutoActive: viewportId => !!get().autoActive[viewportId],
 
-  /**
-   * Marks the given viewport as permanently opted out of auto-scroll.
-   */
   markPermanentlyDisabled: viewportId =>
     set(
       state => ({
@@ -138,14 +85,8 @@ const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
       'markPermanentlyDisabled'
     ),
 
-  /**
-   * Returns whether the given viewport is permanently opted out of auto-scroll.
-   */
   isPermanentlyDisabled: viewportId => !!get().permanentlyDisabled[viewportId],
 
-  /**
-   * Marks the next VOLUME_NEW_IMAGE on the given viewport as programmatic (self-driven).
-   */
   markSelfScroll: viewportId =>
     set(
       state => ({
@@ -155,9 +96,6 @@ const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
       'markSelfScroll'
     ),
 
-  /**
-   * Clears the self-scroll flag for the given viewport.
-   */
   clearSelfScroll: viewportId =>
     set(
       state => {
@@ -169,14 +107,8 @@ const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
       'clearSelfScroll'
     ),
 
-  /**
-   * Returns whether the given viewport currently has a pending self-scroll.
-   */
   isSelfScroll: viewportId => !!get().selfScroll[viewportId],
 
-  /**
-   * Clears the entire Dynamic Auto Scroll store.
-   */
   clearDynamicAutoScrollStore: () =>
     set(
       { autoActive: {}, permanentlyDisabled: {}, selfScroll: {} },
@@ -185,10 +117,6 @@ const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
     ),
 });
 
-/**
- * Zustand store for managing dynamic-volume auto-scroll state across viewports.
- * Applies devtools middleware when DEBUG_STORE is enabled.
- */
 export const useDynamicAutoScrollStore = create<DynamicAutoScrollState>()(
   DEBUG_STORE
     ? devtools(createDynamicAutoScrollStore, { name: 'DynamicAutoScrollStore' })

--- a/extensions/cornerstone/src/stores/useDynamicAutoScrollStore.ts
+++ b/extensions/cornerstone/src/stores/useDynamicAutoScrollStore.ts
@@ -1,0 +1,196 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+/**
+ * Identifier for the Dynamic Auto Scroll store type.
+ */
+const PRESENTATION_TYPE_ID = 'dynamicAutoScrollStoreId';
+
+/**
+ * Flag to enable or disable debug mode for the store.
+ * Set to `true` to enable zustand devtools.
+ */
+const DEBUG_STORE = false;
+
+/**
+ * State shape for the Dynamic Auto Scroll store.
+ */
+type DynamicAutoScrollState = {
+  /**
+   * Type identifier for the store.
+   */
+  type: string;
+
+  /**
+   * Viewports with auto-scroll currently active, keyed by viewportId.
+   */
+  autoActive: Record<string, boolean>;
+
+  /**
+   * Viewports where auto-scroll has been permanently disabled (e.g. after a user scroll),
+   * keyed by viewportId. Prevents re-activation for the rest of the session.
+   */
+  permanentlyDisabled: Record<string, boolean>;
+
+  /**
+   * Viewports with an in-flight programmatic scroll, keyed by viewportId. Used to
+   * distinguish auto-scroll-driven VOLUME_NEW_IMAGE events from user-driven ones.
+   */
+  selfScroll: Record<string, boolean>;
+
+  /**
+   * Marks auto-scroll as active for the given viewport.
+   */
+  markAutoActive: (viewportId: string) => void;
+
+  /**
+   * Clears the active flag for the given viewport.
+   */
+  clearAutoActive: (viewportId: string) => void;
+
+  /**
+   * Returns whether auto-scroll is active for the given viewport.
+   */
+  isAutoActive: (viewportId: string) => boolean;
+
+  /**
+   * Marks the given viewport as permanently opted out of auto-scroll.
+   */
+  markPermanentlyDisabled: (viewportId: string) => void;
+
+  /**
+   * Returns whether the given viewport is permanently opted out of auto-scroll.
+   */
+  isPermanentlyDisabled: (viewportId: string) => boolean;
+
+  /**
+   * Marks the next VOLUME_NEW_IMAGE on the given viewport as programmatic (self-driven).
+   */
+  markSelfScroll: (viewportId: string) => void;
+
+  /**
+   * Clears the self-scroll flag for the given viewport.
+   */
+  clearSelfScroll: (viewportId: string) => void;
+
+  /**
+   * Returns whether the given viewport currently has a pending self-scroll.
+   */
+  isSelfScroll: (viewportId: string) => boolean;
+
+  /**
+   * Clears the entire Dynamic Auto Scroll store.
+   */
+  clearDynamicAutoScrollStore: () => void;
+};
+
+/**
+ * Creates the Dynamic Auto Scroll store.
+ *
+ * @param set - The zustand set function.
+ * @param get - The zustand get function.
+ * @returns The Dynamic Auto Scroll store state and actions.
+ */
+const createDynamicAutoScrollStore = (set, get): DynamicAutoScrollState => ({
+  type: PRESENTATION_TYPE_ID,
+  autoActive: {},
+  permanentlyDisabled: {},
+  selfScroll: {},
+
+  /**
+   * Marks auto-scroll as active for the given viewport.
+   */
+  markAutoActive: viewportId =>
+    set(
+      state => ({ autoActive: { ...state.autoActive, [viewportId]: true } }),
+      false,
+      'markAutoActive'
+    ),
+
+  /**
+   * Clears the active flag for the given viewport.
+   */
+  clearAutoActive: viewportId =>
+    set(
+      state => {
+        const next = { ...state.autoActive };
+        delete next[viewportId];
+        return { autoActive: next };
+      },
+      false,
+      'clearAutoActive'
+    ),
+
+  /**
+   * Returns whether auto-scroll is active for the given viewport.
+   */
+  isAutoActive: viewportId => !!get().autoActive[viewportId],
+
+  /**
+   * Marks the given viewport as permanently opted out of auto-scroll.
+   */
+  markPermanentlyDisabled: viewportId =>
+    set(
+      state => ({
+        permanentlyDisabled: { ...state.permanentlyDisabled, [viewportId]: true },
+      }),
+      false,
+      'markPermanentlyDisabled'
+    ),
+
+  /**
+   * Returns whether the given viewport is permanently opted out of auto-scroll.
+   */
+  isPermanentlyDisabled: viewportId => !!get().permanentlyDisabled[viewportId],
+
+  /**
+   * Marks the next VOLUME_NEW_IMAGE on the given viewport as programmatic (self-driven).
+   */
+  markSelfScroll: viewportId =>
+    set(
+      state => ({
+        selfScroll: { ...state.selfScroll, [viewportId]: true },
+      }),
+      false,
+      'markSelfScroll'
+    ),
+
+  /**
+   * Clears the self-scroll flag for the given viewport.
+   */
+  clearSelfScroll: viewportId =>
+    set(
+      state => {
+        const next = { ...state.selfScroll };
+        delete next[viewportId];
+        return { selfScroll: next };
+      },
+      false,
+      'clearSelfScroll'
+    ),
+
+  /**
+   * Returns whether the given viewport currently has a pending self-scroll.
+   */
+  isSelfScroll: viewportId => !!get().selfScroll[viewportId],
+
+  /**
+   * Clears the entire Dynamic Auto Scroll store.
+   */
+  clearDynamicAutoScrollStore: () =>
+    set(
+      { autoActive: {}, permanentlyDisabled: {}, selfScroll: {} },
+      false,
+      'clearDynamicAutoScrollStore'
+    ),
+});
+
+/**
+ * Zustand store for managing dynamic-volume auto-scroll state across viewports.
+ * Applies devtools middleware when DEBUG_STORE is enabled.
+ */
+export const useDynamicAutoScrollStore = create<DynamicAutoScrollState>()(
+  DEBUG_STORE
+    ? devtools(createDynamicAutoScrollStore, { name: 'DynamicAutoScrollStore' })
+    : createDynamicAutoScrollStore
+);

--- a/extensions/cornerstone/src/utils/dynamicVolumeAutoScroll.ts
+++ b/extensions/cornerstone/src/utils/dynamicVolumeAutoScroll.ts
@@ -1,0 +1,193 @@
+import {
+  Enums,
+  eventTarget,
+  cache,
+  utilities as csCoreUtils,
+  Types,
+  StreamingDynamicImageVolume,
+} from '@cornerstonejs/core';
+import { useDynamicAutoScrollStore } from '../stores/useDynamicAutoScrollStore';
+
+const DEFAULT_FRAME_RATE = 24;
+
+type ViewportAutoScrollState = {
+  volumeId: string;
+  lastDimensionGroup: number | null;
+  numDimensionGroups: number;
+  element: HTMLElement;
+  onDimensionGroupChange: (evt: any) => void;
+  onVolumeNewImage: (evt: any) => void;
+};
+
+const viewportStates = new Map<string, ViewportAutoScrollState>();
+
+function getDynamicVolume(
+  viewport: Types.IVolumeViewport
+): StreamingDynamicImageVolume | undefined {
+  const volumeIds = viewport.getAllVolumeIds?.() ?? [];
+  const volumes = volumeIds.map(id => cache.getVolume(id));
+  return volumes.find(v => v?.isDynamicVolume?.()) as StreamingDynamicImageVolume;
+}
+
+export function activateAutoScroll({
+  servicesManager,
+  viewportId,
+}: {
+  servicesManager: AppTypes.ServicesManager;
+  viewportId: string;
+}) {
+  const store = useDynamicAutoScrollStore.getState();
+
+  if (store.isPermanentlyDisabled(viewportId) || store.isAutoActive(viewportId)) {
+    return;
+  }
+
+  const { cineService, cornerstoneViewportService } = servicesManager.services;
+  const viewport = cornerstoneViewportService.getCornerstoneViewport(
+    viewportId
+  ) as Types.IVolumeViewport;
+  if (!viewport) {
+    return;
+  }
+
+  const volume = getDynamicVolume(viewport);
+  if (!volume) {
+    return;
+  }
+
+  const onDimensionGroupChange = (evt: any) => {
+    const state = viewportStates.get(viewportId);
+    if (!state || evt.detail.volumeId !== state.volumeId) {
+      return;
+    }
+
+    const prev = state.lastDimensionGroup;
+    const current = evt.detail.dimensionGroupNumber;
+    const numGroups = evt.detail.numDimensionGroups ?? state.numDimensionGroups;
+    state.lastDimensionGroup = current;
+    state.numDimensionGroups = numGroups;
+
+    // Wrap: last → first means we've cycled all timepoints; advance one slice.
+    const wrapped = prev !== null && prev === numGroups && current === 1;
+    if (wrapped) {
+      moveToNextSlice({ servicesManager, viewportId });
+    }
+  };
+
+  const onVolumeNewImage = () => {
+    const store = useDynamicAutoScrollStore.getState();
+    if (store.isSelfScroll(viewportId)) {
+      store.clearSelfScroll(viewportId);
+      return;
+    }
+    deactivateAutoScroll({ servicesManager, viewportId, permanent: true });
+  };
+
+  const element = viewport.element;
+
+  eventTarget.addEventListener(
+    Enums.Events.DYNAMIC_VOLUME_DIMENSION_GROUP_CHANGED,
+    onDimensionGroupChange
+  );
+  element.addEventListener(Enums.Events.VOLUME_NEW_IMAGE, onVolumeNewImage);
+
+  viewportStates.set(viewportId, {
+    volumeId: volume.volumeId,
+    lastDimensionGroup: volume.dimensionGroupNumber ?? null,
+    numDimensionGroups: volume.numDimensionGroups,
+    element,
+    onDimensionGroupChange,
+    onVolumeNewImage,
+  });
+
+  store.markAutoActive(viewportId);
+
+  cineService.setIsCineEnabled(true);
+  cineService.setCine({ id: viewportId, isPlaying: true, frameRate: DEFAULT_FRAME_RATE });
+}
+
+function moveToNextSlice({
+  servicesManager,
+  viewportId,
+}: {
+  servicesManager: AppTypes.ServicesManager;
+  viewportId: string;
+}) {
+  const { cornerstoneViewportService } = servicesManager.services;
+  const viewport = cornerstoneViewportService.getCornerstoneViewport(
+    viewportId
+  ) as Types.IVolumeViewport;
+  if (!viewport) {
+    return;
+  }
+
+  const numberOfSlices = viewport.getNumberOfSlices?.() ?? 0;
+  const currentIndex = viewport.getCurrentImageIdIndex?.() ?? 0;
+
+  const store = useDynamicAutoScrollStore.getState();
+  store.markSelfScroll(viewportId);
+
+  if (numberOfSlices > 1 && currentIndex >= numberOfSlices - 1) {
+    // Wrap to the first slice and keep looping.
+    csCoreUtils.jumpToSlice(viewport.element, { imageIndex: 0 });
+  } else {
+    csCoreUtils.scroll(viewport, { delta: 1 });
+  }
+
+  // If the slice didn't change, no event fires to clear the self-scroll flag,
+  // so clear it here. Otherwise onVolumeNewImage handles it.
+  const newIndex = viewport.getCurrentImageIdIndex?.() ?? currentIndex;
+  if (newIndex === currentIndex) {
+    store.clearSelfScroll(viewportId);
+  }
+}
+
+function deactivateAutoScroll({
+  servicesManager,
+  viewportId,
+  permanent,
+}: {
+  servicesManager: AppTypes.ServicesManager;
+  viewportId: string;
+  permanent: boolean;
+}) {
+  const state = viewportStates.get(viewportId);
+  if (state) {
+    eventTarget.removeEventListener(
+      Enums.Events.DYNAMIC_VOLUME_DIMENSION_GROUP_CHANGED,
+      state.onDimensionGroupChange
+    );
+    state.element.removeEventListener(Enums.Events.VOLUME_NEW_IMAGE, state.onVolumeNewImage);
+    viewportStates.delete(viewportId);
+  }
+
+  const store = useDynamicAutoScrollStore.getState();
+  store.clearAutoActive(viewportId);
+  if (permanent) {
+    store.markPermanentlyDisabled(viewportId);
+  }
+
+  const { cineService } = servicesManager.services;
+  cineService.setCine({ id: viewportId, isPlaying: false, frameRate: DEFAULT_FRAME_RATE });
+}
+
+export function stopAutoScroll({
+  servicesManager,
+  viewportId,
+}: {
+  servicesManager: AppTypes.ServicesManager;
+  viewportId: string;
+}) {
+  deactivateAutoScroll({ servicesManager, viewportId, permanent: false });
+}
+
+export function stopAllAutoScroll() {
+  for (const state of viewportStates.values()) {
+    eventTarget.removeEventListener(
+      Enums.Events.DYNAMIC_VOLUME_DIMENSION_GROUP_CHANGED,
+      state.onDimensionGroupChange
+    );
+    state.element.removeEventListener(Enums.Events.VOLUME_NEW_IMAGE, state.onVolumeNewImage);
+  }
+  viewportStates.clear();
+}

--- a/extensions/cornerstone/src/utils/dynamicVolumeAutoScroll.ts
+++ b/extensions/cornerstone/src/utils/dynamicVolumeAutoScroll.ts
@@ -21,6 +21,10 @@ type ViewportAutoScrollState = {
 
 const viewportStates = new Map<string, ViewportAutoScrollState>();
 
+/**
+ * @param viewport Types.IVolumeViewport
+ * @returns returns the first dynamic volume found in the viewport
+ */
 function getDynamicVolume(
   viewport: Types.IVolumeViewport
 ): StreamingDynamicImageVolume | undefined {
@@ -136,7 +140,7 @@ function moveToNextSlice({
 
   // If the slice didn't change, no event fires to clear the self-scroll flag,
   // so clear it here. Otherwise onVolumeNewImage handles it.
-  const newIndex = viewport.getCurrentImageIdIndex?.() ?? currentIndex;
+  const newIndex = viewport.getCurrentImageIdIndex?.();
   if (newIndex === currentIndex) {
     store.clearSelfScroll(viewportId);
   }


### PR DESCRIPTION
## Summary
- Activates per-viewport auto-scroll on `IMAGE_VOLUME_LOADING_COMPLETED` for dynamic volumes, advancing one slice each time the timepoint cycle wraps (looping back to slice 0 at the end).
- User-initiated scroll permanently disables auto-scroll on that viewport for the session; programmatic scrolls are tracked via a `selfScroll` flag to avoid being misread as user input.
- Adds `useDynamicAutoScrollStore` to track per-viewport `autoActive` / `permanentlyDisabled` / `selfScroll` state, and tears down listeners + store on extension `onModeExit`.
- Shows a render-progress `%` overlay on `SmartImageScrollbar` while the volume is still streaming.

## Recording
- Auto-scroll when all slices are loaded

https://github.com/user-attachments/assets/b2b77171-a107-459d-afbc-77e4be9e4e26

## Screenshots
- Render progress
<img width="1915" height="905" alt="image" src="https://github.com/user-attachments/assets/8ce417f5-7f1a-4ede-8c6e-6721b9b4a35f" />

## Test plan
- [ ] Load a dynamic (4D) volume — verify auto-scroll starts after load completes and cycles through all slices/timepoints.
- [ ] Scroll manually mid-playback — verify auto-scroll stops and does not re-activate for that viewport.
- [ ] Exit and re-enter the mode — verify state resets cleanly.
- [ ] Confirm the `%` progress overlay appears during loading and disappears at 100%.
