### PR TITLE
Disabled Dynamic volumes in Frame View

### DIFF
--- a/extensions/cornerstone/src/hps/frameView.ts
+++ b/extensions/cornerstone/src/hps/frameView.ts
@@ -25,6 +25,13 @@ const frameView: Types.HangingProtocol.Protocol = {
             equals: true,
           },
         },
+        {
+          attribute: 'isDynamicVolume',
+          constraint: {
+            equals: { value: false },
+          },
+          required: true,
+        },
       ],
     },
   },


### PR DESCRIPTION
## Summary

Disabled the **Dynamic Volumes** in the **Frame View** by introducing a new `seriesMatching` rule. This change explicitly filters out dynamic volume loading for this specific view configuration, ensuring standard rendering and preventing unintended performance overhead.

## Recording

https://github.com/user-attachments/assets/8087285b-137a-427c-ae2b-b4e5a65085a1