### PR TITLE
Created Lint check CI action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,67 @@
+name: Lint Check
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches:
+      - nightly
+      - production
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install Yarn
+        run: npm install -g yarn@1.22.22
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run ESLint strictly on Changed Lines (Blocking)
+        run: |
+          # 1. Create a temporary config that inherits OHIF's base config
+          # but applies the 'diff/ci' mode to filter output to changed lines only
+          echo '{ "extends": ["./.eslintrc.json", "plugin:diff/ci"] }' > .eslintrc.diff.json
+
+          # 2. Determine the target commit for the git diff comparison
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            export ESLINT_PLUGIN_DIFF_COMMIT="${{ github.event.pull_request.base.sha }}"
+          else
+            BEFORE_COMMIT="${{ github.event.before }}"
+
+            if [ "$BEFORE_COMMIT" = "0000000000000000000000000000000000000000" ]; then
+              # Pushing a brand new branch
+              export ESLINT_PLUGIN_DIFF_COMMIT="HEAD~1"
+            else
+              # Verify if the 'before' commit actually exists in the local checkout
+              if git rev-parse --verify --quiet "$BEFORE_COMMIT" > /dev/null; then
+                export ESLINT_PLUGIN_DIFF_COMMIT="$BEFORE_COMMIT"
+              else
+                # Fallback for force pushes or rebases where the old commit is gone
+                echo "Warning: Commit $BEFORE_COMMIT not found locally. Falling back to HEAD~1"
+                export ESLINT_PLUGIN_DIFF_COMMIT="HEAD~1"
+              fi
+            fi
+          fi
+
+          # 3. Execute ESLint across the codebase using the temporary diff config
+          yarn eslint --max-warnings=0 --config .eslintrc.diff.json --ext .js,.jsx,.ts,.tsx .

--- a/addOns/externals/devDependencies/package.json
+++ b/addOns/externals/devDependencies/package.json
@@ -42,6 +42,7 @@
     "eslint-config-prettier": "7.2.0",
     "eslint-config-react-app": "6.0.0",
     "eslint-plugin-cypress": "2.15.2",
+    "eslint-plugin-diff": "2.1.7",
     "eslint-plugin-flowtype": "7.0.0",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jsx-a11y": "6.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8579,6 +8579,11 @@ eslint-plugin-cypress@2.15.2:
   dependencies:
     globals "^13.20.0"
 
+eslint-plugin-diff@2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-diff/-/eslint-plugin-diff-2.1.7.tgz#a1a86af2f659f37c9357753d2529fdc745880d48"
+  integrity sha512-F0EP5knbELQRPX7A4ogFFty+Pyru6CtUFmt52VSJ+7I84UsOj5s+BtY/ZhQFdvmPkFzKqVy+g5IHP+iiaUu/Aw==
+
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"


### PR DESCRIPTION
## Add ESLint CI Lint Check

### Description
Introduces a GitHub Actions workflow that runs ESLint on every push and PR.
Scoped to only changed lines so existing lint debt doesn't block new work.

### What's included
* **CI/CD Integration (`.github/workflows/lint.yml`)**
* Uses `eslint-plugin-diff/ci` to lint only changed lines.
* Runs on pushes and PRs targeting nightly/production.
* Handles force pushes, new branches, and auto-cancels redundant runs.

### Dependencies
* Adds `eslint-plugin-diff@2.1.7` as a dev dependency.