### PR TITLE
ATL-1135 - Register laplace-pacs as a viewer data source

### DIFF
--- a/platform/app/public/config/gradient_production.js
+++ b/platform/app/public/config/gradient_production.js
@@ -1412,6 +1412,24 @@ window.config = {
       },
     },
     {
+      namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
+      sourceName: 'laplace-pacs/v1.0',
+      configuration: {
+        friendlyName: 'Cloud Optimized wado proxy server for Laplace',
+        name: 'cod-laplace',
+        qidoRoot: 'https://storage.googleapis.com/laplace-pacs/v1.0/dicomweb',
+        wadoRoot: 'https://storage.googleapis.com/laplace-pacs/v1.0/dicomweb',
+        useCod: true,
+        imageRendering: 'wadors',
+        thumbnailRendering: 'wadors',
+        enableStudyLazyLoad: true,
+        staticWado: false,
+        bulkDataURI: {
+          enabled: false,
+        },
+      },
+    },
+    {
       friendlyName: 'dicom json',
       namespace: '@gradienthealth/ohif-gradienthealth-extension.dataSourcesModule.bq',
       sourceName: 'bq',


### PR DESCRIPTION
Gradient Vault embeds the atlas OHIF viewer on its exam page and, for dev, reads from the synthetic `laplace-pacs` bucket. That bucket was never registered as a per-bucket DICOMweb data source, so the only option was the generic `cod?bucket=…` source — which does not render the bucket's COD v2.0 data. Registering a dedicated per-bucket source (as ~38 hospital buckets already have) makes v2.0 render correctly.

- Add a `laplace-pacs/v1.0` data source to `gradient_production.js`, mirroring the existing per-bucket entries (qidoRoot/wadoRoot at `https://storage.googleapis.com/laplace-pacs/v1.0/dicomweb`, `useCod: true`).
- Reachable at `/atlas/viewer/laplace-pacs/v1.0` once the gh-pages viewer redeploys.

laplace data is not de-identified, so only the `-pacs/v1.0` entry is added (no `-pacs-deid`). Bucket-side infra (CORS for `gradienthealth.github.io`, runtime SA `objectViewer`) is already in place — no atlas-side or bucket changes needed. Merging to `production` auto-triggers the gh-pages redeploy.