### PR TITLE
PROC-2274: URL-encode the COD GCS list prefix so custom flag-set '+' survives

### DIFF
--- a/extensions/default/src/DicomWebDataSource/codDicomWebServerWrapper.js
+++ b/extensions/default/src/DicomWebDataSource/codDicomWebServerWrapper.js
@@ -519,7 +519,12 @@ class CodDicomWebServerClient {
 
     const studyMetadata = studyuids.map(async (/** @type {string} */ deidStudyInstanceuid) => {
       const folderPath = `${bucketPrefix}/studies/${deidStudyInstanceuid}/series/`;
-      const apiUrl = `${domain}/storage/v1/b/${bucket}/o?prefix=${folderPath}&delimiter=${delimiter}`;
+      // Encode the prefix: a custom-export bucketPrefix can contain a literal '+'
+      // (e.g. a flag-set like "disable-document-detection+no_header_footer"), which
+      // GCS would otherwise decode to a space in the query string and never match.
+      const apiUrl = `${domain}/storage/v1/b/${bucket}/o?prefix=${encodeURIComponent(
+        folderPath
+      )}&delimiter=${delimiter}`;
       const response = await fetch(apiUrl, { headers });
       const res = await response.json();
       const folders = res.prefixes || [];


### PR DESCRIPTION
## Problem

Custom-export cohorts reviewed in the OHIF viewer (via the dynamic `cod` data source) load no images. The COD data source lists a study's series with:

```
https://storage.googleapis.com/storage/v1/b/<bucket>/o?prefix=<folderPath>&delimiter=/
```

`folderPath` is concatenated into the query string **raw**. Custom de-id buckets use a flag-set path segment that can contain a literal `+`, e.g.:

```
disable-document-detection+no_document_no_header_footer_config/raw/v1.0/dicomweb/studies/<study>/series/
```

In a query string GCS decodes `+`→space, so the prefix never matches → `res.prefixes` is empty → no series → blank viewer.

Verified against live GCS (the exact list call):

| `?prefix=…` | result |
|---|---|
| `…detection+no_document…` (raw `+`) | `<Prefix>…detection no_document…</Prefix>` → **0 keys** |
| `…detection%2Bno_document…` (`%2B`) | returns `…tar`, `index.sqlite`, `metadata.json` ✅ |

## Fix

`encodeURIComponent(folderPath)` in the list URL (`codDicomWebServerWrapper.js`). Backward-compatible: canonical prefixes (`v1.0/dicomweb/…`) contain no `+`, and `/` round-trips through GCS as `%2F`→`/`.

## Related

- **Companion PR:** gradienthealth/review-service#217 routes custom-bucket series through this `cod` data source (PROC-2189 emitted only the path form, which has no statically-registered data source). **Both are required** for custom-export review viewing to work.
- The same raw-concat pattern exists in the DicomSeg **write** paths (lines ~338/363) — out of scope here (not exercised by review viewing); flagged for follow-up.
- Linear: PROC-2274.

> Base note: targeted at `production` (the deployed atlas branch / `origin/HEAD`). Retarget to your integration branch (e.g. `nightly`) if that's the preferred flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)