### PR TITLE
PROC-2396: render gated NM (RECON GATED TOMO) as a stack, not a volume

### DIFF
--- a/platform/core/src/utils/isDisplaySetReconstructable.js
+++ b/platform/core/src/utils/isDisplaySetReconstructable.js
@@ -87,7 +87,14 @@ function hasPosition(multiFrameInstance) {
 
 function isNMReconstructable(multiFrameInstance) {
   const imageSubType = multiFrameInstance.ImageType?.[2];
-  return imageSubType === 'RECON TOMO' || imageSubType === 'RECON GATED TOMO';
+  const isTomo = imageSubType === 'RECON TOMO' || imageSubType === 'RECON GATED TOMO';
+  // A gated study packs one volume per gate (NumberOfTimeSlots) into a single
+  // multiframe instance that carries only one position/orientation, so its
+  // frames repeat the same slice positions per gate and can't form one volume.
+  // Render it as a stack instead; only non-gated tomo is a single volume.
+  const isGated =
+    imageSubType === 'RECON GATED TOMO' || Number(multiFrameInstance.NumberOfTimeSlots) > 1;
+  return isTomo && !isGated;
 }
 
 function processMultiframe(multiFrameInstance) {

--- a/platform/core/src/utils/isDisplaySetReconstructable.test.js
+++ b/platform/core/src/utils/isDisplaySetReconstructable.test.js
@@ -1,0 +1,64 @@
+import isDisplaySetReconstructable, { isNMReconstructable } from './isDisplaySetReconstructable';
+
+// A minimal multiframe NM instance that satisfies the pixel-measures,
+// orientation, and position checks, so the NM gated/non-gated branch is what
+// decides reconstructability. Gated SPECT packs one volume per gate into a
+// single instance (NumberOfFrames = NumberOfSlices * NumberOfTimeSlots), so it
+// must render as a stack, not a single volume (PROC-2396).
+function nmMultiframe(overrides = {}) {
+  return {
+    NumberOfFrames: 400,
+    Rows: 64,
+    Columns: 64,
+    Modality: 'NM',
+    ImageType: ['ORIGINAL', 'PRIMARY', 'RECON TOMO', 'EMISSION'],
+    PixelSpacing: [4.92, 4.92],
+    SliceThickness: 4.92,
+    ImageOrientationPatient: [1, 0, 0, 0, 1, 0],
+    ImagePositionPatient: [0, 0, 0],
+    ...overrides,
+  };
+}
+
+describe('isDisplaySetReconstructable — NM tomographic', () => {
+  test('non-gated RECON TOMO is reconstructable (renders as a volume)', () => {
+    expect(isDisplaySetReconstructable([nmMultiframe()]).value).toBe(true);
+  });
+
+  test('RECON GATED TOMO is not reconstructable (falls back to a stack)', () => {
+    const instance = nmMultiframe({
+      ImageType: ['ORIGINAL', 'PRIMARY', 'RECON GATED TOMO', 'EMISSION'],
+      NumberOfTimeSlots: 8,
+    });
+    expect(isDisplaySetReconstructable([instance]).value).toBe(false);
+  });
+
+  test('gating detected via NumberOfTimeSlots > 1 even if ImageType says RECON TOMO', () => {
+    expect(isDisplaySetReconstructable([nmMultiframe({ NumberOfTimeSlots: 8 })]).value).toBe(false);
+  });
+});
+
+describe('isNMReconstructable', () => {
+  test('true for non-gated RECON TOMO', () => {
+    expect(isNMReconstructable({ ImageType: ['ORIGINAL', 'PRIMARY', 'RECON TOMO'] })).toBe(true);
+  });
+
+  test('false for RECON GATED TOMO', () => {
+    expect(isNMReconstructable({ ImageType: ['ORIGINAL', 'PRIMARY', 'RECON GATED TOMO'] })).toBe(
+      false
+    );
+  });
+
+  test('false for RECON TOMO with more than one time slot (gated)', () => {
+    expect(
+      isNMReconstructable({
+        ImageType: ['ORIGINAL', 'PRIMARY', 'RECON TOMO'],
+        NumberOfTimeSlots: 8,
+      })
+    ).toBe(false);
+  });
+
+  test('false for non-tomographic NM (e.g. planar/static)', () => {
+    expect(isNMReconstructable({ ImageType: ['ORIGINAL', 'PRIMARY'] })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Gated nuclear-medicine SPECT series (`ImageType[2] === 'RECON GATED TOMO'`) render as a **blank** viewport in the atlas viewer. This makes them fall back to a stack viewport so they render.

## Why
A gated SPECT instance packs one volume per cardiac gate into a single multiframe instance — `NumberOfFrames = NumberOfSlices × NumberOfTimeSlots` (e.g. 50 × 8 = 400) — with a single position/orientation and no per-frame positions. `isNMReconstructable` treated `RECON GATED TOMO` as reconstructable, so the hanging protocol built one 3-D volume. The 8 gates repeat the same 50 slice positions, so cornerstone can't resolve a consistent volume grid (`getClosestImageId: No imageId found within … half spacing`, then `WebGL: uniformMatrix3fv: no array`) and nothing renders. The pixels decode fine — this is viewport selection / geometry, not data or codec.

Full investigation: [PROC-2395](https://linear.app/gradienthealth/issue/PROC-2395/investigate-failing-viewer-links-for-goldeneyes). Fix ticket: [PROC-2396](https://linear.app/gradienthealth/issue/PROC-2396/render-gated-nm-recon-gated-tomo-as-a-stack-not-a-volume). Follow-up (per-gate volume split): [PROC-2397](https://linear.app/gradienthealth/issue/PROC-2397/split-gated-nm-multiframe-into-per-gate-volumes).

## Change
`isNMReconstructable` now excludes gated tomo (`RECON GATED TOMO`, or `NumberOfTimeSlots > 1`); only non-gated `RECON TOMO` stays reconstructable. Gated NM therefore renders as a scrollable stack.

## Test plan
- Unit: `platform/core/src/utils/isDisplaySetReconstructable.test.js` (7 tests) — gated → stack, non-gated `RECON TOMO` → volume, gating-via-`NumberOfTimeSlots`.
- Manual (post atlas rebuild/redeploy): the goldeneye NM gated series render as a scrollable stack; a non-gated NM `RECON TOMO` series still renders as a volume.

## Scope
NM gated-SPECT only. The third failing link in PROC-2395 (`…812057`) is a single-frame CT `LOCALIZER` — a separate failure, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
